### PR TITLE
fix(countrylist): correct null-selection state and clean up styling

### DIFF
--- a/.changeset/soft-cars-work.md
+++ b/.changeset/soft-cars-work.md
@@ -1,0 +1,5 @@
+---
+"audience-atlas": patch
+---
+
+fix(countrylist): correct null-selection state and clean up styling

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import { CountryList } from "@/components/CountryList";
 function App() {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [size, setSize] = useState<{ width: number; height: number } | null>(null);
-	const [country, setCountry] = useState<string>("NO_COUNTRY_SELECTED");
+	const [country, setCountry] = useState<string | null>(null);
 
 	const [credentials, setCredentials] = useState<Credentials>({
 		user: "",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import { CountryList } from "@/components/CountryList";
 function App() {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [size, setSize] = useState<{ width: number; height: number } | null>(null);
-	const [country, setCountry] = useState<string | null>(null);
+	const [country, setCountry] = useState<string>("NO_COUNTRY_SELECTED");
 
 	const [credentials, setCredentials] = useState<Credentials>({
 		user: "",
@@ -107,7 +107,11 @@ function App() {
 						}
 					</main>
 					<aside className='w-64 shrink-0 border-l border-border bg-card p-6 hidden md:block'>
-						<CountryList data={audience} country={country} />
+						<CountryList
+							data={audience}
+							country={country}
+							setCountry={(country) => setCountry(country)}
+						/>
 					</aside>
 				</div>
 			)}

--- a/src/components/CountryFlag.tsx
+++ b/src/components/CountryFlag.tsx
@@ -15,7 +15,7 @@ const FLAG_COMPONENTS = Flags as unknown as Record<
 
 function CountryFlagBase({
 	isoCode,
-	className = "h-full w-full object-cover"
+	className = "h-4 w-6 object-cover"
 }: CountryFlagProps) {
 	const code = isoCode.toUpperCase();
 	const label = getRegionName(code);

--- a/src/components/CountryFlag.tsx
+++ b/src/components/CountryFlag.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import * as Flags from "country-flag-icons/react/3x2";
+import { hasFlag } from "country-flag-icons";
+
+interface CountryFlagProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+	isoCode: string;
+}
+
+export const CountryFlag: React.FC<CountryFlagProps> = ({ isoCode }) => {
+	const formattedCode = isoCode.toUpperCase();
+
+	if (!hasFlag(formattedCode)) {
+		return <span>{formattedCode}</span>;
+	}
+
+	const FlagComponent = (
+		Flags as Record<string, React.ComponentType<{ className?: string }>>
+	)[formattedCode as keyof typeof Flags];
+
+	return <FlagComponent className='h-full w-full object-cover' />;
+};

--- a/src/components/CountryFlag.tsx
+++ b/src/components/CountryFlag.tsx
@@ -1,21 +1,37 @@
-import React from "react";
+import { memo, type ComponentType, type SVGProps } from "react";
 import * as Flags from "country-flag-icons/react/3x2";
 import { hasFlag } from "country-flag-icons";
+import { getRegionName } from "@/lib/region";
 
-interface CountryFlagProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+interface CountryFlagProps {
 	isoCode: string;
+	className?: string;
 }
 
-export const CountryFlag: React.FC<CountryFlagProps> = ({ isoCode }) => {
-	const formattedCode = isoCode.toUpperCase();
+const FLAG_COMPONENTS = Flags as unknown as Record<
+	string,
+	ComponentType<SVGProps<SVGSVGElement>>
+>;
 
-	if (!hasFlag(formattedCode)) {
-		return <span>{formattedCode}</span>;
+function CountryFlagBase({
+	isoCode,
+	className = "h-full w-full object-cover"
+}: CountryFlagProps) {
+	const code = isoCode.toUpperCase();
+	const label = getRegionName(code);
+
+	if (!hasFlag(code)) {
+		return (
+			<span className={className} role='img' aria-label={label}>
+				{code}
+			</span>
+		);
 	}
 
-	const FlagComponent = (
-		Flags as Record<string, React.ComponentType<{ className?: string }>>
-	)[formattedCode as keyof typeof Flags];
+	const Flag = FLAG_COMPONENTS[code];
+	return <Flag className={className} role='img' aria-label={label} />;
+}
 
-	return <FlagComponent className='h-full w-full object-cover' />;
-};
+CountryFlagBase.displayName = "CountryFlag";
+
+export const CountryFlag = memo(CountryFlagBase);

--- a/src/components/CountryList.tsx
+++ b/src/components/CountryList.tsx
@@ -4,22 +4,13 @@ import type { AudienceData, LocalizedGithubProfile } from "@/types/api.types";
 import { CountryFlag } from "@/components/CountryFlag";
 import { Button } from "@/components/ui/button";
 import { X } from "lucide-react";
+import { getRegionName } from "@/lib/region";
 
 interface CountryListProps {
 	data: AudienceData;
 	title?: string;
 	country: string;
 	setCountry: (arg: string) => void;
-}
-
-const regionNames = new Intl.DisplayNames(["en"], { type: "region" });
-
-function getSafeRegionName(code: string): string {
-	try {
-		return regionNames.of(code) || code;
-	} catch {
-		return code;
-	}
 }
 
 export function CountryList({
@@ -81,7 +72,7 @@ export function CountryList({
 											:	<div className='h-full w-full bg-muted-foreground/20' />}
 										</div>
 										<span className='truncate font-medium text-foreground'>
-											{getSafeRegionName(countryCode)}
+											{getRegionName(countryCode)}
 										</span>
 									</div>
 									<span className='font-mono text-xs font-semibold text-muted-foreground'>
@@ -97,7 +88,7 @@ export function CountryList({
 						<hr className='my-4 border-border' />
 						<div className='space-y-1'>
 							<h4 className='mb-2 px-3 text-xs font-medium text-muted-foreground'>
-								Profiles in {getSafeRegionName(country!)}{" "}
+								Profiles in {getRegionName(country!)}{" "}
 								<CountryFlag isoCode={country} />
 							</h4>
 							{selectedProfiles.map((profile) => (
@@ -124,7 +115,7 @@ export function CountryList({
 						<hr className='my-4 border-border' />
 						<div className='space-y-1'>
 							<h4 className='mb-2 px-3 text-xs font-medium text-muted-foreground'>
-								Profiles in {getSafeRegionName(country!)}{" "}
+								Profiles in {getRegionName(country!)}{" "}
 								<CountryFlag isoCode={country} />
 							</h4>
 						</div>

--- a/src/components/CountryList.tsx
+++ b/src/components/CountryList.tsx
@@ -1,16 +1,14 @@
-import React, { useMemo } from "react";
-import * as Flags from "country-flag-icons/react/3x2";
+import { useMemo } from "react";
+import { X } from "lucide-react";
 import type { AudienceData, LocalizedGithubProfile } from "@/types/api.types";
 import { CountryFlag } from "@/components/CountryFlag";
-import { Button } from "@/components/ui/button";
-import { X } from "lucide-react";
 import { getRegionName } from "@/lib/region";
 
 interface CountryListProps {
 	data: AudienceData;
 	title?: string;
-	country: string;
-	setCountry: (arg: string) => void;
+	country: string | null;
+	setCountry: (arg: string | null) => void;
 }
 
 export function CountryList({
@@ -33,94 +31,89 @@ export function CountryList({
 		);
 	}, [usersByCountry]);
 
-	const selectedProfiles = usersByCountry.get(country) || country;
+	const selectedProfiles = country ? (usersByCountry.get(country) ?? []) : null;
 
 	return (
-		<div className='flex h-full flex-col gap-4 relative'>
-			<Button
-				size={"icon-sm"}
-				className={"absolute -top-6 -right-6"}
-				type='reset'
-				onClick={() => setCountry("NO_COUNTRY_SELECTED")}>
-				<X size='60' />
-			</Button>
-			<div className='flex items-center justify-between'>
-				<h3 className='text-sm font-semibold tracking-tight text-foreground'>
-					{title}
-				</h3>
-				<span className='font-mono text-xs text-muted-foreground'>
-					{usersByCountry.size} regions
+		<div className='flex h-full flex-col gap-4'>
+			<div className='flex items-center justify-between gap-2'>
+				{country ?
+					<button
+						type='button'
+						onClick={() => setCountry(null)}
+						className='inline-flex min-w-0 items-center gap-2 rounded-full border border-border bg-muted/40 py-1 pl-2 pr-1 text-sm font-medium text-foreground transition-colors hover:bg-muted'>
+						<CountryFlag
+							isoCode={country}
+							className='h-3.5 w-5 shrink-0 rounded-sm'
+						/>
+						<span className='truncate'>{getRegionName(country)}</span>
+						<span className='flex h-4 w-4 items-center justify-center rounded-full text-muted-foreground hover:text-foreground'>
+							<X size={12} />
+						</span>
+					</button>
+				:	<h3 className='text-sm font-semibold tracking-tight text-foreground'>
+						{title}
+					</h3>
+				}
+				<span className='shrink-0 font-mono text-xs text-muted-foreground'>
+					{country ? usersByCountry.get(country)?.length : usersByCountry.size}
 				</span>
 			</div>
 
 			<div className='scrollbar-thin flex-1 overflow-y-auto pr-2 [scrollbar-color:var(--color-border)_transparent]'>
-				<div className='space-y-1'>
-					{selectedProfiles === "NO_COUNTRY_SELECTED"
-						&& sortedCountries.map(([countryCode, profiles]) => {
-							const FlagComponent = (
-								Flags as Record<string, React.ComponentType<{ className?: string }>>
-							)[countryCode.toUpperCase()];
-
-							return (
-								<div
-									key={countryCode}
-									className='flex items-center justify-between rounded-lg px-3 py-2 text-sm transition-colors hover:bg-muted/50'>
-									<div className='flex min-w-0 items-center gap-3'>
-										<div className='shadow-xs flex h-4 w-6 shrink-0 overflow-hidden rounded-sm border border-border/40 bg-muted object-cover'>
-											{FlagComponent ?
-												<FlagComponent className='h-full w-full object-cover' />
-											:	<div className='h-full w-full bg-muted-foreground/20' />}
-										</div>
-										<span className='truncate font-medium text-foreground'>
-											{getRegionName(countryCode)}
-										</span>
-									</div>
-									<span className='font-mono text-xs font-semibold text-muted-foreground'>
-										{profiles.length}
+				{selectedProfiles === null && (
+					<div className='space-y-1'>
+						{sortedCountries.map(([code, profiles]) => (
+							<div
+								key={code}
+								role='button'
+								tabIndex={0}
+								onClick={() => setCountry(code)}
+								onKeyDown={(e) => e.key === "Enter" && setCountry(code)}
+								className='flex cursor-pointer items-center justify-between rounded-lg px-3 py-2 text-sm hover:bg-muted/50'>
+								<div className='flex min-w-0 items-center gap-3'>
+									<CountryFlag
+										isoCode={code}
+										className='h-4 w-6 shrink-0 rounded-sm border border-border/40'
+									/>
+									<span className='truncate font-medium text-foreground'>
+										{getRegionName(code)}
 									</span>
 								</div>
-							);
-						})}
-				</div>
+								<span className='font-mono text-xs font-semibold text-muted-foreground'>
+									{profiles.length}
+								</span>
+							</div>
+						))}
+					</div>
+				)}
 
-				{typeof selectedProfiles !== "string" && selectedProfiles.length > 0 ?
-					<>
-						<hr className='my-4 border-border' />
-						<div className='space-y-1'>
-							<h4 className='mb-2 px-3 text-xs font-medium text-muted-foreground'>
-								Profiles in {getRegionName(country!)}{" "}
-								<CountryFlag isoCode={country} />
-							</h4>
-							{selectedProfiles.map((profile) => (
+				{selectedProfiles !== null && (
+					<div className='space-y-1'>
+						{selectedProfiles.length > 0 ?
+							selectedProfiles.map((profile) => (
 								<div
 									key={profile.id}
 									className='flex items-center justify-between rounded-lg px-3 py-2 text-sm transition-colors hover:bg-muted/50'>
-									<div className='flex min-w-0 items-center gap-3'>
-										<div className='shadow-xs flex h-9 w-9 items-center justify-center shrink-0 overflow-hidden rounded-sm border border-border/40 bg-muted object-cover text-[10px] font-mono'>
-											<img
-												src={profile.avatar_url}
-												alt={profile.login}
-												className='w-9 h-9 rounded-full border border-border shrink-0'
-											/>
-										</div>
-										<span className='truncate font-medium text-foreground'>
-											{profile.name}
-										</span>
+									<div className='flex min-w-0 items-center justify-evenly gap-3'>
+										<img
+											src={profile.avatar_url}
+											alt={profile.login}
+											className='h-9 w-9 shrink-0 rounded-full border border-border'
+										/>
+										<a href={profile.html_url} target='_blank'>
+											<span className='truncate font-medium text-foreground'>
+												{profile.name}
+											</span>
+										</a>
 									</div>
 								</div>
-							))}
-						</div>
-					</>
-				:	<>
-						<hr className='my-4 border-border' />
-						<div className='space-y-1'>
-							<h4 className='mb-2 px-3 text-xs font-medium text-muted-foreground'>
-								Profiles in {getRegionName(country!)}{" "}
-								<CountryFlag isoCode={country} />
-							</h4>
-						</div>
-					</>
-				}
+							))
+						:	<p className='px-3 py-6 text-center text-sm text-muted-foreground'>
+								No followers from this region yet.
+							</p>
+						}
+					</div>
+				)}
 			</div>
 		</div>
 	);

--- a/src/components/CountryList.tsx
+++ b/src/components/CountryList.tsx
@@ -1,11 +1,15 @@
 import React, { useMemo } from "react";
 import * as Flags from "country-flag-icons/react/3x2";
 import type { AudienceData, LocalizedGithubProfile } from "@/types/api.types";
+import { CountryFlag } from "@/components/CountryFlag";
+import { Button } from "@/components/ui/button";
+import { X } from "lucide-react";
 
 interface CountryListProps {
 	data: AudienceData;
 	title?: string;
-	country: string | null;
+	country: string;
+	setCountry: (arg: string) => void;
 }
 
 const regionNames = new Intl.DisplayNames(["en"], { type: "region" });
@@ -21,7 +25,8 @@ function getSafeRegionName(code: string): string {
 export function CountryList({
 	data,
 	title = "Audience by Country",
-	country
+	country,
+	setCountry
 }: CountryListProps) {
 	const usersByCountry = useMemo(() => {
 		return data.followers.reduce((acc, user) => {
@@ -37,10 +42,17 @@ export function CountryList({
 		);
 	}, [usersByCountry]);
 
-	const selectedProfiles = country ? usersByCountry.get(country) : undefined;
+	const selectedProfiles = usersByCountry.get(country) || country;
 
 	return (
-		<div className='flex h-full flex-col gap-4'>
+		<div className='flex h-full flex-col gap-4 relative'>
+			<Button
+				size={"icon-sm"}
+				className={"absolute -top-6 -right-6"}
+				type='reset'
+				onClick={() => setCountry("NO_COUNTRY_SELECTED")}>
+				<X size='60' />
+			</Button>
 			<div className='flex items-center justify-between'>
 				<h3 className='text-sm font-semibold tracking-tight text-foreground'>
 					{title}
@@ -52,7 +64,7 @@ export function CountryList({
 
 			<div className='scrollbar-thin flex-1 overflow-y-auto pr-2 [scrollbar-color:var(--color-border)_transparent]'>
 				<div className='space-y-1'>
-					{!selectedProfiles
+					{selectedProfiles === "NO_COUNTRY_SELECTED"
 						&& sortedCountries.map(([countryCode, profiles]) => {
 							const FlagComponent = (
 								Flags as Record<string, React.ComponentType<{ className?: string }>>
@@ -80,12 +92,13 @@ export function CountryList({
 						})}
 				</div>
 
-				{selectedProfiles && selectedProfiles.length > 0 && (
+				{typeof selectedProfiles !== "string" && selectedProfiles.length > 0 ?
 					<>
 						<hr className='my-4 border-border' />
 						<div className='space-y-1'>
 							<h4 className='mb-2 px-3 text-xs font-medium text-muted-foreground'>
 								Profiles in {getSafeRegionName(country!)}{" "}
+								<CountryFlag isoCode={country} />
 							</h4>
 							{selectedProfiles.map((profile) => (
 								<div
@@ -107,7 +120,16 @@ export function CountryList({
 							))}
 						</div>
 					</>
-				)}
+				:	<>
+						<hr className='my-4 border-border' />
+						<div className='space-y-1'>
+							<h4 className='mb-2 px-3 text-xs font-medium text-muted-foreground'>
+								Profiles in {getSafeRegionName(country!)}{" "}
+								<CountryFlag isoCode={country} />
+							</h4>
+						</div>
+					</>
+				}
 			</div>
 		</div>
 	);

--- a/src/lib/region.ts
+++ b/src/lib/region.ts
@@ -1,0 +1,9 @@
+const regionNames = new Intl.DisplayNames(["en"], { type: "region" });
+
+export function getRegionName(code: string): string {
+	try {
+		return regionNames.of(code) ?? code;
+	} catch {
+		return code;
+	}
+}


### PR DESCRIPTION
**Description**:
Fixes a UI bug where selecting a country with zero followers showed a blank panel, plus some layout cleanup that was piggybacking on the same component.

**Changes**:

- Replace "NO_COUNTRY_SELECTED" sentinel string with country: string | null, removes the ghost "Profiles in NO_COUNTRY_SELECTED" render on initial load
- Decouple the detail header from selectedProfiles.length > 0, so a selected country with no followers now renders a proper empty state instead of nothing
- Make country rows clickable (onClick + onKeyDown), previously had hover styles but no way to select
- Replace floating X button (absolute -top-6 -right-6, coupled to parent's padding) with an inline chip (flag + name + X) in normal document flow
- Fix oversized flag in detail header by giving CountryFlag an explicit default size instead of h-full w-full
- Extract getRegionName into lib/region.ts, shared between CountryFlag and CountryList instead of duplicated