### PR TITLE
feat(map): display the audience by the selected category(followers, following, ghost)

### DIFF
--- a/.changeset/sixty-hotels-add.md
+++ b/.changeset/sixty-hotels-add.md
@@ -1,0 +1,5 @@
+---
+"audience-atlas": minor
+---
+
+feat(map): display the audience by the selected category(followers, following, ghost)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,8 @@ import { ErrorView } from "@/components/ErrorView";
 import { WorldMap } from "@/components/WorldMap";
 import { CountryList } from "@/components/CountryList";
 
+type AudienceType = "followers" | "following" | "ghosts";
+
 function App() {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [size, setSize] = useState<{ width: number; height: number } | null>(null);
@@ -19,6 +21,8 @@ function App() {
 		user: "",
 		token: ""
 	});
+
+	const [audienceType, setAudienceType] = useState<AudienceType>("followers");
 
 	const { status, steps, error, pct, estimate, user, audience, resetAt } =
 		useAudience(credentials);
@@ -99,7 +103,7 @@ function App() {
 								width={size.width}
 								height={size.height}
 								setCountry={setCountry}
-								audience={audience}
+								audience={audience[audienceType]}
 							/>
 						:	<div className='absolute inset-0 flex items-center justify-center text-sm text-muted-foreground'>
 								Calculating map dimensions...
@@ -108,7 +112,7 @@ function App() {
 					</main>
 					<aside className='w-64 shrink-0 border-l border-border bg-card p-6 hidden md:block'>
 						<CountryList
-							data={audience}
+							data={audience[audienceType]}
 							country={country}
 							setCountry={(country) => setCountry(country)}
 						/>
@@ -116,7 +120,14 @@ function App() {
 				</div>
 			)}
 			<footer className='h-8 w-full border-t border-border bg-muted/40 px-6 flex items-center justify-between text-xs text-muted-foreground shrink-0'>
-				<p>© 2026 Your Company</p>
+				<p>© 2026 Atals Audience</p>
+				{
+					<div className='flex gap-5 text-xs font-medium text-foreground truncate'>
+						<span onClick={() => setAudienceType("followers")}>follower</span>
+						<span onClick={() => setAudienceType("following")}>following</span>
+						<span onClick={() => setAudienceType("ghosts")}>ghost</span>
+					</div>
+				}
 				<div className='flex gap-4'>
 					<a href='#' className='hover:underline'>
 						Privacy

--- a/src/components/CountryList.tsx
+++ b/src/components/CountryList.tsx
@@ -1,11 +1,11 @@
 import { useMemo } from "react";
 import { X } from "lucide-react";
-import type { AudienceData, LocalizedGithubProfile } from "@/types/api.types";
+import type { LocalizedGithubProfile } from "@/types/api.types";
 import { CountryFlag } from "@/components/CountryFlag";
 import { getRegionName } from "@/lib/region";
 
 interface CountryListProps {
-	data: AudienceData;
+	data: LocalizedGithubProfile[];
 	title?: string;
 	country: string | null;
 	setCountry: (arg: string | null) => void;
@@ -18,12 +18,12 @@ export function CountryList({
 	setCountry
 }: CountryListProps) {
 	const usersByCountry = useMemo(() => {
-		return data.followers.reduce((acc, user) => {
+		return data.reduce((acc, user) => {
 			const regionalUsers = acc.get(user.country) || [];
 			regionalUsers.push(user);
 			return acc.set(user.country, regionalUsers);
 		}, new Map<string, LocalizedGithubProfile[]>());
-	}, [data.followers]);
+	}, [data]);
 
 	const sortedCountries = useMemo(() => {
 		return Array.from(usersByCountry.entries()).sort(

--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -1,5 +1,5 @@
 import { getCountryColor, MAP_BASE_STYLING } from "@/lib/getCountryColor";
-import type { AudienceData, LocalizedGithubProfile } from "@/types/api.types";
+import type { LocalizedGithubProfile } from "@/types/api.types";
 import * as d3 from "d3";
 import type { Geometry } from "geojson";
 import { useEffect, useMemo, useState } from "react";
@@ -24,7 +24,7 @@ export interface WorldMapProps {
 	width: number;
 	height: number;
 	setCountry: (country: string) => void;
-	audience: AudienceData;
+	audience: LocalizedGithubProfile[];
 }
 
 export const WorldMap = ({
@@ -72,11 +72,11 @@ export const WorldMap = ({
 	}, [geoJson, pathGenerator]);
 
 	const profilesByCountry = useMemo(() => {
-		return audience.followers.reduce((acc, profile) => {
+		return audience.reduce((acc, profile) => {
 			const regionalProfiles = acc.get(profile.country) || [];
 			return acc.set(profile.country, regionalProfiles);
 		}, new Map<string, LocalizedGithubProfile[]>());
-	}, [audience.followers]);
+	}, [audience]);
 
 	if (!geoJson) {
 		return (


### PR DESCRIPTION
It let user to choose which of the three options of audience he want to display on both of the map and the panel.
- create a state on top level `App` component that gives it to `CountryList` and `WorldMap` component.
- Set the category option at the footer page