### PR TITLE
fix(map): glow effect to apply only on continent edges

### DIFF
--- a/.changeset/heavy-moons-lick.md
+++ b/.changeset/heavy-moons-lick.md
@@ -1,0 +1,5 @@
+---
+"audience-atlas": patch
+---
+
+fix(map): glow effect to apply only on continent edges

--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -115,7 +115,6 @@ export const WorldMap = ({
 								`${getCountryColor(country.id)}`
 							:	MAP_BASE_STYLING.defaultFill
 						}
-						filter={MAP_BASE_STYLING.glowEffect}
 						stroke={MAP_BASE_STYLING.borderColor}
 						strokeWidth={MAP_BASE_STYLING.borderWidth}
 						style={{ transition: "all 0.2s ease" }}

--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -105,7 +105,24 @@ export const WorldMap = ({
 					stroke='#bcc3d1'
 					strokeWidth={0.05}></path>
 			</g>
-			<g>
+			<defs>
+				<filter id='map-glow' x='-20%' y='-20%' width='140%' height='140%'>
+					<feGaussianBlur stdDeviation='15' result='blur' />
+					<feFlood flood-color='rgba(0, 255, 239, 0.25)' result='color' />
+					<feComposite in='color' in2='blur' operator='in' result='coloredGlow' />
+					<feComposite
+						in='coloredGlow'
+						in2='SourceAlpha'
+						operator='out'
+						result='hollowGlow'
+					/>
+					<feMerge>
+						<feMergeNode in='hollowGlow' />
+						<feMergeNode in='SourceGraphic' />
+					</feMerge>
+				</filter>
+			</defs>
+			<g filter='url(#map-glow)'>
 				{mapPaths.map((country) => (
 					<path
 						key={`${country.id}-${country.name}`}

--- a/src/lib/getCountryColor.ts
+++ b/src/lib/getCountryColor.ts
@@ -184,8 +184,7 @@ export const MAP_BASE_STYLING = {
 	defaultFill: "#1E1E24",
 	borderColor: "#FFFFFF",
 	borderWidth: 0.125,
-	highlightFill: "#00E5FF",
-	glowEffect: "drop-shadow(0px 0px 24px rgba(0, 229, 255, 0.15))"
+	highlightFill: "#00E5FF"
 };
 
 export function getCountryColor(isoAlpha2Eh: string): string {


### PR DESCRIPTION
**Context & IssuePreviously** 
the glow effect was applied individually to each country's <path>. this caused visual overlapping, where internal borders between neighboring countries also received the glow effect, creating unwanted artifacting in the inland areas of the continent.
**Changes**
- Removed individual effects: Stripped the glowEffect filter from each country's `<path>` element.
- Created global filter: introduced a unified, global filter designed for the entire landmass.
- Applied to continent container: applied this new global filter directly to the continent's parent group (`<g>`) so the glow now correctly outlines only the outer perimeter of the continent. 

**Visual Impact**
Internal country borders are now clean and unaffected by the glow.The entire continent now shares a single, cohesive outer glow effect.