### PR TITLE
fix: increase the timeout of the ai review response

### DIFF
--- a/.changeset/social-comics-tease.md
+++ b/.changeset/social-comics-tease.md
@@ -1,0 +1,5 @@
+---
+"audience-atlas": patch
+---
+
+ci: increase the timeout of the ai response

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -131,7 +131,7 @@ jobs:
               last_err = None
               for attempt in range(1, max_attempts + 1):
                   try:
-                      with urllib.request.urlopen(request, timeout=60) as resp:
+                      with urllib.request.urlopen(request, timeout=180) as resp:
                           return json.loads(resp.read())
                   except urllib.error.HTTPError as e:
                       last_err = e


### PR DESCRIPTION
The CI pipeline fails because the AI API request times out before the task completes.