### PR TITLE
fix(map): resolve globe drag stutter, back-face click bug, and projection dependencies

### DIFF
--- a/.changeset/polite-dragons-teach.md
+++ b/.changeset/polite-dragons-teach.md
@@ -1,0 +1,5 @@
+---
+"audience-atlas": patch
+---
+
+fix: decouple position from visibility & capture on drag, not on down

--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useMemo, useRef } from "react";
 import type { LocalizedGithubProfile } from "@/api/graphql.types";
 import { useGeoJson } from "@/hooks/useGeoJson";
 import { MAP_BASE_STYLING } from "@/lib/getCountryColor";
@@ -10,7 +10,6 @@ import { useCountryPaths, type WorldGeoJson } from "@/hooks/useCountryPaths";
 import { useHeatScale } from "@/hooks/useHeatScale";
 import { useProfilesByCountry } from "@/hooks/useProfilesByCountry";
 import { getRegionName } from "@/lib/region";
-import { useMemo } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Card } from "@/components/ui/card";
 import { useGlobeRotation } from "@/hooks/useGlobeRotation";
@@ -179,6 +178,9 @@ export const WorldMap = ({
 						const hasData = count > 0;
 						const isSelected =
 							selectedCountry !== null && country.id === selectedCountry;
+
+						if (!country.svgPath) return null;
+
 						return (
 							<path
 								key={`${country.id}-${country.name}`}
@@ -189,8 +191,11 @@ export const WorldMap = ({
 										`hsl(var(--signal) / ${heatScale(count).toFixed(2)})`
 									:	MAP_BASE_STYLING.defaultFill
 								}
-								style={{ opacity: country.opacity }}
-								className={`transition-[fill,stroke,opacity] duration-300 ease-in-out cursor-pointer stroke-accent-foreground hover:stroke-[1.5px] hover:brightness-110 focus:outline-none ${
+								style={{
+									opacity: country.opacity,
+									pointerEvents: country.opacity < 0.1 ? "none" : "auto"
+								}}
+								className={`transition-[fill,stroke] duration-300 ease-in-out cursor-pointer stroke-accent-foreground hover:stroke-[1.5px] hover:brightness-110 focus:outline-none ${
 									isSelected ? "stroke-[2px] stroke-primary" : "stroke-[0.05px]"
 								}`}
 								onClick={() => setCountry(isSelected ? null : country.id)}
@@ -210,7 +215,7 @@ export const WorldMap = ({
 								</span>
 								<button
 									onClick={() => setCountry(null)}
-									className='text-muted-foreground hover:text-foreground rounded-sm p-0.5'>
+									className='text-muted-foreground hover:text-foreground rounded-sm p-0.5 cursor-pointer'>
 									<X className='h-3.5 w-3.5' />
 								</button>
 							</div>
@@ -269,7 +274,7 @@ export const WorldMap = ({
 					}
 				</Card>
 			</div>
-			<div className='absolute top-3 left-3 sm:top-auto sm:left-auto sm:bottom-6 sm:right-6 z-10 flex items-center gap-3  pointer-events-none p-3.5 bg-card/85 backdrop-blur-md border-border/50  rounded-md'>
+			<div className='absolute top-3 left-3 sm:top-auto sm:left-auto sm:bottom-6 sm:right-6 z-10 flex items-center gap-3 pointer-events-none p-3.5 bg-card/85 backdrop-blur-md border border-border/50 rounded-md'>
 				<Avatar className='h-10 w-10 border-2 border-primary/20 shadow-sm bg-card'>
 					<AvatarImage src={avatarUrl} crossOrigin='anonymous' />
 					<AvatarFallback>{username.substring(0, 2).toUpperCase()}</AvatarFallback>
@@ -292,7 +297,7 @@ export const WorldMap = ({
 					onClick={handleExport}
 					disabled={isExporting}
 					title='Save snapshot'
-					className='h-10 w-10 sm:h-9 sm:w-9 bg-card border border-border shadow-sm'>
+					className='h-10 w-10 sm:h-9 sm:w-9 bg-card border border-border shadow-sm cursor-pointer'>
 					{justExported ?
 						<Check className='h-4 w-4 text-primary' />
 					:	<Camera className={`h-4 w-4 ${isExporting ? "animate-pulse" : ""}`} />}

--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -126,7 +126,7 @@ export const WorldMap = ({
 				ref={svgRef}
 				width={width}
 				height={height}
-				className={`bg-(--map-space) ${isDragging ? "cursor-grabbing" : "cursor-grab"}`}
+				className={`bg-(--map-space) touch-none ${isDragging ? "cursor-grabbing" : "cursor-grab"}`}
 				{...dragHandlers}>
 				<defs>
 					<filter id='map-glow' x='-60%' y='-60%' width='220%' height='220%'>
@@ -189,7 +189,8 @@ export const WorldMap = ({
 										`hsl(var(--signal) / ${heatScale(count).toFixed(2)})`
 									:	MAP_BASE_STYLING.defaultFill
 								}
-								className={`transition-colors duration-300 ease-in-out cursor-pointer stroke-accent-foreground hover:stroke-[1.5px] hover:brightness-110 focus:outline-none ${
+								style={{ opacity: country.opacity }}
+								className={`transition-[fill,stroke,opacity] duration-300 ease-in-out cursor-pointer stroke-accent-foreground hover:stroke-[1.5px] hover:brightness-110 focus:outline-none ${
 									isSelected ? "stroke-[2px] stroke-primary" : "stroke-[0.05px]"
 								}`}
 								onClick={() => setCountry(isSelected ? null : country.id)}

--- a/src/hooks/useCountryPaths.ts
+++ b/src/hooks/useCountryPaths.ts
@@ -1,8 +1,11 @@
+// src/hooks/useCountryPaths.ts
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
+	geoCentroid,
 	geoNaturalEarth1,
 	geoOrthographic,
 	geoPath,
+	geoRotation,
 	geoTransform,
 	type GeoStream
 } from "d3-geo";
@@ -29,6 +32,12 @@ export interface CountryPath {
 	id: string;
 	name: string;
 	svgPath: string;
+	opacity: number;
+}
+
+function smoothstep(edge0: number, edge1: number, x: number) {
+	const t = Math.min(1, Math.max(0, (x - edge0) / (edge1 - edge0)));
+	return t * t * (3 - 2 * t);
 }
 
 export function useCountryPaths(
@@ -103,9 +112,6 @@ export function useCountryPaths(
 	);
 
 	const pathGenerator = useMemo(() => {
-		if (progress === 0) return geoPath().projection(p2d);
-		if (progress === 1) return geoPath().projection(p3d);
-
 		const interpolatingProjection = geoTransform({
 			point: function (this: { stream: GeoStream }, lon: number, lat: number) {
 				const pt2d = p2d([lon, lat]);
@@ -121,16 +127,44 @@ export function useCountryPaths(
 		});
 
 		return geoPath().projection(interpolatingProjection);
-	}, [p2d, p3d, p3dRaw, progress, width, height]);
+	}, [p2d, p3dRaw, progress]);
+
+	const centroids = useMemo(() => {
+		const map = new Map<string, [number, number]>();
+		geoJson?.features.forEach((f) => {
+			map.set(f.properties.ISO_A2_EH, geoCentroid(f));
+		});
+		return map;
+	}, [geoJson]);
+
+	const rotate = useMemo(() => geoRotation(rotation), [rotation]);
+
+	const visibilityBlend = smoothstep(0.55, 0.9, progress);
 
 	const mapPaths = useMemo(() => {
 		if (!geoJson) return [];
-		return geoJson.features.map((feature) => ({
-			id: feature.properties.ISO_A2_EH,
-			name: feature.properties.NAME_EN,
-			svgPath: pathGenerator(feature) || ""
-		}));
-	}, [geoJson, pathGenerator]);
+		const rad = Math.PI / 180;
+
+		return geoJson.features.map((feature) => {
+			const id = feature.properties.ISO_A2_EH;
+			const centroid = centroids.get(id);
+
+			let opacity = 1;
+			if (centroid) {
+				const [rLon, rLat] = rotate(centroid);
+				const cosC = Math.cos(rLat * rad) * Math.cos(rLon * rad);
+				const frontFactor = smoothstep(-0.06, 0.06, cosC);
+				opacity = 1 - visibilityBlend * (1 - frontFactor);
+			}
+
+			return {
+				id,
+				name: feature.properties.NAME_EN,
+				svgPath: pathGenerator(feature) || "",
+				opacity
+			};
+		});
+	}, [geoJson, pathGenerator, centroids, rotate, visibilityBlend]);
 
 	const sphere2D = useMemo(
 		() => (geoPath().projection(p2d)({ type: "Sphere" }) as string) || "",

--- a/src/hooks/useCountryPaths.ts
+++ b/src/hooks/useCountryPaths.ts
@@ -1,4 +1,3 @@
-// src/hooks/useCountryPaths.ts
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
 	geoCentroid,
@@ -55,7 +54,7 @@ export function useCountryPaths(
 	const [progress, setProgress] = useState(mode === "GLOBE" ? 1 : 0);
 	const progressRef = useRef(progress);
 	const animRef = useRef<number | null>(null);
-	const duration = 750;
+	const DURATION = 750;
 
 	useEffect(() => {
 		progressRef.current = progress;
@@ -65,29 +64,26 @@ export function useCountryPaths(
 		const target = mode === "GLOBE" ? 1 : 0;
 		const startProgress = progressRef.current;
 		const startTime = performance.now();
-		const frameInterval = 1000 / 30;
-		let lastFrameTime = startTime;
 
 		const animate = (now: number) => {
 			const elapsed = now - startTime;
-			const t = Math.min(1, elapsed / duration);
+			const t = Math.min(1, elapsed / DURATION);
 			const ease = t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
 
-			if (now - lastFrameTime >= frameInterval || t >= 1) {
-				lastFrameTime = now;
-				setProgress(startProgress + (target - startProgress) * ease);
-			}
+			setProgress(startProgress + (target - startProgress) * ease);
 
 			if (t < 1) {
 				animRef.current = requestAnimationFrame(animate);
 			}
 		};
 
+		if (animRef.current) cancelAnimationFrame(animRef.current);
 		animRef.current = requestAnimationFrame(animate);
+
 		return () => {
 			if (animRef.current) cancelAnimationFrame(animRef.current);
 		};
-	}, [mode, duration]);
+	}, [mode]);
 
 	const p2d = useMemo(
 		() => geoNaturalEarth1().fitSize([width, height], { type: "Sphere" }),
@@ -98,7 +94,8 @@ export function useCountryPaths(
 		() =>
 			geoOrthographic()
 				.fitSize([width, height], { type: "Sphere" })
-				.rotate(rotation),
+				.rotate(rotation)
+				.clipAngle(90),
 		[width, height, rotation]
 	);
 
@@ -111,7 +108,14 @@ export function useCountryPaths(
 		[width, height, rotation]
 	);
 
-	const pathGenerator = useMemo(() => {
+	const activePathGenerator = useMemo(() => {
+		if (progress === 0) {
+			return geoPath().projection(p2d);
+		}
+		if (progress === 1) {
+			return geoPath().projection(p3d);
+		}
+
 		const interpolatingProjection = geoTransform({
 			point: function (this: { stream: GeoStream }, lon: number, lat: number) {
 				const pt2d = p2d([lon, lat]);
@@ -127,7 +131,7 @@ export function useCountryPaths(
 		});
 
 		return geoPath().projection(interpolatingProjection);
-	}, [p2d, p3dRaw, progress]);
+	}, [p2d, p3d, p3dRaw, progress]);
 
 	const centroids = useMemo(() => {
 		const map = new Map<string, [number, number]>();
@@ -138,7 +142,6 @@ export function useCountryPaths(
 	}, [geoJson]);
 
 	const rotate = useMemo(() => geoRotation(rotation), [rotation]);
-
 	const visibilityBlend = smoothstep(0.55, 0.9, progress);
 
 	const mapPaths = useMemo(() => {
@@ -150,7 +153,7 @@ export function useCountryPaths(
 			const centroid = centroids.get(id);
 
 			let opacity = 1;
-			if (centroid) {
+			if (centroid && progress > 0) {
 				const [rLon, rLat] = rotate(centroid);
 				const cosC = Math.cos(rLat * rad) * Math.cos(rLon * rad);
 				const frontFactor = smoothstep(-0.06, 0.06, cosC);
@@ -160,11 +163,11 @@ export function useCountryPaths(
 			return {
 				id,
 				name: feature.properties.NAME_EN,
-				svgPath: pathGenerator(feature) || "",
+				svgPath: activePathGenerator(feature) || "",
 				opacity
 			};
 		});
-	}, [geoJson, pathGenerator, centroids, rotate, visibilityBlend]);
+	}, [geoJson, activePathGenerator, centroids, rotate, visibilityBlend, progress]);
 
 	const sphere2D = useMemo(
 		() => (geoPath().projection(p2d)({ type: "Sphere" }) as string) || "",

--- a/src/hooks/useGlobeRotation.ts
+++ b/src/hooks/useGlobeRotation.ts
@@ -1,9 +1,10 @@
-// src/hooks/useGlobeRotation.ts
 import { useCallback, useEffect, useRef, useState } from "react";
 import { geoCentroid } from "d3-geo";
 import type { CountryFeature, WorldGeoJson } from "@/hooks/useCountryPaths";
 
 const DRAG_THRESHOLD_PX = 6;
+const DRAG_SENSITIVITY = 0.4;
+const ROTATION_ANIMATION_MS = 750;
 
 export function useGlobeRotation(
 	selectedCountry: string | null | undefined,
@@ -47,20 +48,24 @@ export function useGlobeRotation(
 				e.currentTarget.setPointerCapture(e.pointerId);
 			}
 
-			const sensitivity = 0.5;
-			const newRotation: [number, number, number] = [
-				dragStartRef.current.rotation[0] + dx * sensitivity,
-				dragStartRef.current.rotation[1] - dy * sensitivity,
+			const nextRotation: [number, number, number] = [
+				dragStartRef.current.rotation[0] + dx * DRAG_SENSITIVITY,
+				Math.max(
+					-90,
+					Math.min(90, dragStartRef.current.rotation[1] - dy * DRAG_SENSITIVITY)
+				),
 				0
 			];
-			newRotation[1] = Math.max(-90, Math.min(90, newRotation[1]));
-			setRotation(newRotation);
+			setRotation(nextRotation);
 		},
 		[isDragging]
 	);
 
 	const onPointerUp = useCallback((e: React.PointerEvent) => {
-		if (e.currentTarget.hasPointerCapture?.(e.pointerId)) {
+		if (
+			pointerIdRef.current !== null
+			&& e.currentTarget.hasPointerCapture?.(e.pointerId)
+		) {
 			e.currentTarget.releasePointerCapture(e.pointerId);
 		}
 		pointerIdRef.current = null;
@@ -70,38 +75,47 @@ export function useGlobeRotation(
 
 	useEffect(() => {
 		if (!selectedCountry || !geoJson) return;
+
 		const feature = geoJson.features.find(
 			(f: CountryFeature) => f.properties.ISO_A2_EH === selectedCountry
 		);
 		if (!feature) return;
+
 		const centroid = geoCentroid(feature);
+		if (isNaN(centroid[0]) || isNaN(centroid[1])) return;
+
 		const targetRotation: [number, number, number] = [
 			-centroid[0],
 			-centroid[1],
 			0
 		];
 		const startRotation = currentRotationRef.current;
-		let dLambda = targetRotation[0] - startRotation[0];
-		dLambda = dLambda % 360;
+
+		let dLambda = (targetRotation[0] - startRotation[0]) % 360;
 		if (dLambda < -180) dLambda += 360;
 		if (dLambda > 180) dLambda -= 360;
+
 		const startTime = performance.now();
-		const duration = 750;
+
 		const animate = (time: number) => {
 			const elapsed = time - startTime;
-			const progress = Math.min(elapsed / duration, 1);
-			const ease = 1 - Math.pow(1 - progress, 3);
+			const progress = Math.min(elapsed / ROTATION_ANIMATION_MS, 1);
+			const ease = 1 - Math.pow(1 - progress, 3); // Cubic ease-out
+
 			setRotation([
 				startRotation[0] + dLambda * ease,
 				startRotation[1] + (targetRotation[1] - startRotation[1]) * ease,
 				0
 			]);
+
 			if (progress < 1) {
 				animationRef.current = requestAnimationFrame(animate);
 			}
 		};
+
 		if (animationRef.current) cancelAnimationFrame(animationRef.current);
 		animationRef.current = requestAnimationFrame(animate);
+
 		return () => {
 			if (animationRef.current) cancelAnimationFrame(animationRef.current);
 		};

--- a/src/hooks/useGlobeRotation.ts
+++ b/src/hooks/useGlobeRotation.ts
@@ -1,6 +1,9 @@
+// src/hooks/useGlobeRotation.ts
 import { useCallback, useEffect, useRef, useState } from "react";
 import { geoCentroid } from "d3-geo";
 import type { CountryFeature, WorldGeoJson } from "@/hooks/useCountryPaths";
+
+const DRAG_THRESHOLD_PX = 6;
 
 export function useGlobeRotation(
 	selectedCountry: string | null | undefined,
@@ -9,12 +12,12 @@ export function useGlobeRotation(
 	const [rotation, setRotation] = useState<[number, number, number]>([0, 0, 0]);
 	const currentRotationRef = useRef(rotation);
 	const [isDragging, setIsDragging] = useState(false);
-
 	const dragStartRef = useRef<{
 		x: number;
 		y: number;
 		rotation: [number, number, number];
 	} | null>(null);
+	const pointerIdRef = useRef<number | null>(null);
 	const animationRef = useRef<number | null>(null);
 
 	useEffect(() => {
@@ -23,8 +26,7 @@ export function useGlobeRotation(
 
 	const onPointerDown = useCallback((e: React.PointerEvent) => {
 		if (animationRef.current) cancelAnimationFrame(animationRef.current);
-		e.currentTarget.setPointerCapture(e.pointerId);
-		setIsDragging(true);
+		pointerIdRef.current = e.pointerId;
 		dragStartRef.current = {
 			x: e.clientX,
 			y: e.clientY,
@@ -34,10 +36,16 @@ export function useGlobeRotation(
 
 	const onPointerMove = useCallback(
 		(e: React.PointerEvent) => {
-			if (!isDragging || !dragStartRef.current) return;
+			if (!dragStartRef.current || e.pointerId !== pointerIdRef.current) return;
 
 			const dx = e.clientX - dragStartRef.current.x;
 			const dy = e.clientY - dragStartRef.current.y;
+
+			if (!isDragging) {
+				if (Math.hypot(dx, dy) < DRAG_THRESHOLD_PX) return;
+				setIsDragging(true);
+				e.currentTarget.setPointerCapture(e.pointerId);
+			}
 
 			const sensitivity = 0.5;
 			const newRotation: [number, number, number] = [
@@ -45,7 +53,6 @@ export function useGlobeRotation(
 				dragStartRef.current.rotation[1] - dy * sensitivity,
 				0
 			];
-
 			newRotation[1] = Math.max(-90, Math.min(90, newRotation[1]));
 			setRotation(newRotation);
 		},
@@ -56,18 +63,17 @@ export function useGlobeRotation(
 		if (e.currentTarget.hasPointerCapture?.(e.pointerId)) {
 			e.currentTarget.releasePointerCapture(e.pointerId);
 		}
-		setIsDragging(false);
+		pointerIdRef.current = null;
 		dragStartRef.current = null;
+		setIsDragging(false);
 	}, []);
 
 	useEffect(() => {
 		if (!selectedCountry || !geoJson) return;
-
 		const feature = geoJson.features.find(
 			(f: CountryFeature) => f.properties.ISO_A2_EH === selectedCountry
 		);
 		if (!feature) return;
-
 		const centroid = geoCentroid(feature);
 		const targetRotation: [number, number, number] = [
 			-centroid[0],
@@ -75,34 +81,27 @@ export function useGlobeRotation(
 			0
 		];
 		const startRotation = currentRotationRef.current;
-
 		let dLambda = targetRotation[0] - startRotation[0];
 		dLambda = dLambda % 360;
 		if (dLambda < -180) dLambda += 360;
 		if (dLambda > 180) dLambda -= 360;
-
 		const startTime = performance.now();
 		const duration = 750;
-
 		const animate = (time: number) => {
 			const elapsed = time - startTime;
 			const progress = Math.min(elapsed / duration, 1);
 			const ease = 1 - Math.pow(1 - progress, 3);
-
 			setRotation([
 				startRotation[0] + dLambda * ease,
 				startRotation[1] + (targetRotation[1] - startRotation[1]) * ease,
 				0
 			]);
-
 			if (progress < 1) {
 				animationRef.current = requestAnimationFrame(animate);
 			}
 		};
-
 		if (animationRef.current) cancelAnimationFrame(animationRef.current);
 		animationRef.current = requestAnimationFrame(animate);
-
 		return () => {
 			if (animationRef.current) cancelAnimationFrame(animationRef.current);
 		};


### PR DESCRIPTION
This is follow up from PR #47 
Fixes performance bottlenecks during globe interaction and resolves an issue where invisible countries on the back of the globe were intercepting clicks over ocean areas.

- `Performance`: Removed opacity from CSS transition classes in WorldMap.tsx to stop transition calculations on every rotation frame.
- `Back-Face Click Bug`: Enabled native D3 horizon clipping (clipAngle(90)) in 3D mode and added pointerEvents: "none" for occluded back-face paths so ocean clicks register correctly.
- `Projection Logic`: Updated useCountryPaths to dynamically use clipped orthographic projection in static 3D mode and unclipped projection only during active 2D-to-3D morph transitions.