### PR TITLE
fix(map): pointer capture and map render for zero-dimension layout

### DIFF
--- a/.changeset/ready-trains-grow.md
+++ b/.changeset/ready-trains-grow.md
@@ -1,0 +1,5 @@
+---
+"audience-atlas": patch
+---
+
+fix: the issue where dragging or rotating the map accidentally toggled country selection upon pointer release, and resolves broken country click interactions caused by eager DOM pointer capture.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -284,7 +284,7 @@ export default function App() {
 							<div
 								ref={mapContainerRef}
 								className='flex-1 relative overflow-hidden'>
-								{size ?
+								{size && size.width > 0 && size.height > 0 ?
 									<WorldMap
 										mapMode={mapMode}
 										width={size.width}

--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -66,7 +66,7 @@ export const WorldMap = ({
 		handleWheel
 	} = useMapZoom(1);
 
-	const { rotation, pan, isDragging, dragHandlers } = useGlobeRotation(
+	const { rotation, pan, isDragging, justDragged, dragHandlers } = useGlobeRotation(
 		selectedCountry,
 		geoJson,
 		zoom,
@@ -225,7 +225,13 @@ export const WorldMap = ({
 								className={`transition-[fill,stroke] duration-300 ease-in-out cursor-pointer stroke-accent-foreground hover:stroke-[1.5px] hover:brightness-110 focus:outline-none ${
 									isSelected ? "stroke-[2px] stroke-primary" : "stroke-[0.05px]"
 								}`}
-								onClick={() => setCountry(isSelected ? null : country.id)}
+								onClick={(e) => {
+									if (isDragging || justDragged()) {
+										e.stopPropagation();
+										return;
+									}
+									setCountry(isSelected ? null : country.id);
+								}}
 							/>
 						);
 					})}

--- a/src/hooks/useGlobeRotation.ts
+++ b/src/hooks/useGlobeRotation.ts
@@ -3,6 +3,7 @@ import { geoCentroid } from "d3-geo";
 import type { CountryFeature, WorldGeoJson } from "@/hooks/useCountryPaths";
 import type { MAP_MODE } from "@/App";
 
+const DRAG_THRESHOLD_PX = 6;
 const BASE_DRAG_SENSITIVITY = 0.4;
 const ANIMATION_MS = 750;
 
@@ -14,39 +15,54 @@ export function useGlobeRotation(
 	width: number,
 	height: number
 ) {
+	const isGlobe = mapMode === "GLOBE";
+
 	const [rotation, setRotation] = useState<[number, number, number]>([0, 0, 0]);
 	const [pan, setPan] = useState<[number, number]>([0, 0]);
 	const [isDragging, setIsDragging] = useState(false);
 
 	const currentRotationRef = useRef(rotation);
+	const wasDraggingRef = useRef(false);
 	const dragStartRef = useRef<{
 		x: number;
 		y: number;
 		rot: [number, number, number];
 		pan: [number, number];
+		pointerId: number;
+		captured: boolean;
 	} | null>(null);
 	const animationRef = useRef<number | null>(null);
+
 	useEffect(() => {
 		currentRotationRef.current = rotation;
 	}, [rotation]);
+
+	useEffect(() => {
+		if (zoom <= 1) {
+			// eslint-disable-next-line react-hooks/set-state-in-effect
+			setPan([0, 0]);
+		}
+	}, [zoom]);
+
 	const effectivePan: [number, number] = zoom <= 1 ? [0, 0] : pan;
 
 	const onPointerDown = useCallback(
 		(e: React.PointerEvent) => {
 			if (animationRef.current) cancelAnimationFrame(animationRef.current);
 
-			if (mapMode === "SPHERE" && zoom <= 1) return;
+			if (!isGlobe && zoom <= 1) return;
 
-			setIsDragging(true);
+			wasDraggingRef.current = false;
 			dragStartRef.current = {
 				x: e.clientX,
 				y: e.clientY,
 				rot: currentRotationRef.current,
-				pan: effectivePan
+				pan: effectivePan,
+				pointerId: e.pointerId,
+				captured: false
 			};
-			e.currentTarget.setPointerCapture(e.pointerId);
 		},
-		[mapMode, zoom, effectivePan]
+		[isGlobe, zoom, effectivePan]
 	);
 
 	const onPointerMove = useCallback(
@@ -56,15 +72,23 @@ export function useGlobeRotation(
 			const dx = e.clientX - dragStartRef.current.x;
 			const dy = e.clientY - dragStartRef.current.y;
 
-			if (mapMode === "SPHERE") {
-				const maxX = Math.max(0, (width * zoom - width) / 2);
-				const maxY = Math.max(0, (height * zoom - height) / 2);
+			if (!wasDraggingRef.current) {
+				if (Math.hypot(dx, dy) < DRAG_THRESHOLD_PX) return;
 
-				setPan([
-					Math.max(-maxX, Math.min(maxX, dragStartRef.current.pan[0] + dx)),
-					Math.max(-maxY, Math.min(maxY, dragStartRef.current.pan[1] + dy))
-				]);
-			} else {
+				wasDraggingRef.current = true;
+				setIsDragging(true);
+
+				if (!dragStartRef.current.captured && e.currentTarget.setPointerCapture) {
+					try {
+						e.currentTarget.setPointerCapture(e.pointerId);
+						dragStartRef.current.captured = true;
+					} catch {
+						// Edge case fallback
+					}
+				}
+			}
+
+			if (isGlobe) {
 				const sensitivity = BASE_DRAG_SENSITIVITY / zoom;
 				setRotation([
 					dragStartRef.current.rot[0] + dx * sensitivity,
@@ -74,26 +98,42 @@ export function useGlobeRotation(
 					),
 					0
 				]);
+			} else {
+				const maxX = Math.max(0, (width * zoom - width) / 2);
+				const maxY = Math.max(0, (height * zoom - height) / 2);
+
+				setPan([
+					Math.max(-maxX, Math.min(maxX, dragStartRef.current.pan[0] + dx)),
+					Math.max(-maxY, Math.min(maxY, dragStartRef.current.pan[1] + dy))
+				]);
 			}
 		},
-		[mapMode, zoom, width, height]
+		[isGlobe, zoom, width, height]
 	);
 
 	const onPointerUp = useCallback((e: React.PointerEvent) => {
-		if (dragStartRef.current) {
+		if (dragStartRef.current?.captured) {
 			try {
-				e.currentTarget.releasePointerCapture(e.pointerId);
+				if (
+					e.currentTarget.hasPointerCapture
+					&& e.currentTarget.hasPointerCapture(e.pointerId)
+				) {
+					e.currentTarget.releasePointerCapture(e.pointerId);
+				}
 			} catch (err) {
 				console.warn("Failed to release pointer capture:", err);
 			}
 		}
+
 		dragStartRef.current = null;
 		setIsDragging(false);
+		setTimeout(() => {
+			wasDraggingRef.current = false;
+		}, 100);
 	}, []);
 
 	useEffect(() => {
-		if (mapMode === "SPHERE") return;
-		if (!selectedCountry || !geoJson) return;
+		if (!isGlobe || !selectedCountry || !geoJson) return;
 
 		const feature = geoJson.features.find(
 			(f: CountryFeature) => f.properties.ISO_A2_EH === selectedCountry
@@ -137,12 +177,13 @@ export function useGlobeRotation(
 		return () => {
 			if (animationRef.current) cancelAnimationFrame(animationRef.current);
 		};
-	}, [selectedCountry, geoJson, mapMode]);
+	}, [selectedCountry, geoJson, isGlobe]);
 
 	return {
 		rotation,
 		pan: effectivePan,
 		isDragging,
+		justDragged: () => wasDraggingRef.current,
 		dragHandlers: {
 			onPointerDown,
 			onPointerMove,


### PR DESCRIPTION
Fixes an issue where dragging or rotating the map accidentally toggled country selection upon pointer release, and resolves broken country click interactions caused by eager DOM pointer capture.

**Root Cause**

1. **Eager Pointer Capture:** Acquiring `setPointerCapture` immediately on `pointerdown` rerouted target events away from child `<path>` elements, breaking native `onClick` handlers.
2. **State Sync Race Condition:** Asynchronous React state updates for `isDragging` caused `<path onClick>` to fire after `isDragging` had already reset to `false` at the end of a drag event.
3. **Zero-Dimension Initialization:** Mounting `<WorldMap>` prior to `ResizeObserver` completing initial layout passed `width: 0` and `height: 0` to D3 projection functions, causing invalid path strings.

**Changes Made**
- **`useGlobeRotation.ts`**:
  - Deferred `setPointerCapture` until movement passes the `DRAG_THRESHOLD_PX` boundary in `onPointerMove`.
  - Added `wasDraggingRef` with a 100ms lock window on `pointerup` to synchronously block trailing click events.
  - Exposed `justDragged()` helper function to expose raw ref status to consumers.

- **`WorldMap.tsx`**:
  - Updated `<path onClick>` handlers to guard against both `isDragging` and `justDragged()`.

- **`App.tsx`**:
  - Added explicit check `size.width > 0 && size.height > 0` before rendering `<WorldMap>`.

**Verification Steps**

1. **Click Interaction:** Click on various countries in both 2D (Flat) and 3D (Globe) modes to confirm region stats card updates properly.
2. **Drag Interaction:** Drag/rotate the map and release the cursor over a country. Verify the country is **not** selected upon release.
3. **Zoom & Pan:** Zoom in on 2D mode, pan around, and verify pan operations do not trigger country selection on release.
6. **Initial Render:** Hard-refresh the page and verify layout mounts cleanly without SVG path calculation errors in the console.