### PR TITLE
refactor(map): decompose useGlobeRotation into modular custom hooks

### DIFF
--- a/.changeset/breezy-otters-follow.md
+++ b/.changeset/breezy-otters-follow.md
@@ -1,0 +1,5 @@
+---
+"audience-atlas": minor
+---
+
+refactor(useGlobeRotation): split it into three distinctive separation of concern, and avoid re-inventing features already provide by d3

--- a/src/components/WorldMap.tsx
+++ b/src/components/WorldMap.tsx
@@ -66,7 +66,7 @@ export const WorldMap = ({
 		handleWheel
 	} = useMapZoom(1);
 
-	const { rotation, pan, isDragging, justDragged, dragHandlers } = useGlobeRotation(
+	const { rotation, pan, isDragging, didDrag, dragHandlers } = useGlobeRotation(
 		selectedCountry,
 		geoJson,
 		zoom,
@@ -226,7 +226,7 @@ export const WorldMap = ({
 									isSelected ? "stroke-[2px] stroke-primary" : "stroke-[0.05px]"
 								}`}
 								onClick={(e) => {
-									if (isDragging || justDragged()) {
+									if (didDrag()) {
 										e.stopPropagation();
 										return;
 									}

--- a/src/hooks/useGlobeAnimation.ts
+++ b/src/hooks/useGlobeAnimation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { geoCentroid } from "d3-geo";
 import type { CountryFeature, WorldGeoJson } from "@/hooks/useCountryPaths";
 
@@ -14,9 +14,9 @@ export function useGlobeAnimation(
 	const animationRef = useRef<number | null>(null);
 	const rotationRef = useRef(rotation);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		rotationRef.current = rotation;
-	});
+	}, [rotation]);
 
 	const cancelAnimation = useCallback(() => {
 		if (animationRef.current !== null) {

--- a/src/hooks/useGlobeAnimation.ts
+++ b/src/hooks/useGlobeAnimation.ts
@@ -8,9 +8,15 @@ export function useGlobeAnimation(
 	selectedCountry: string | null | undefined,
 	geoJson: WorldGeoJson | null,
 	isGlobe: boolean,
+	rotation: [number, number, number],
 	setRotation: React.Dispatch<React.SetStateAction<[number, number, number]>>
 ) {
 	const animationRef = useRef<number | null>(null);
+	const rotationRef = useRef(rotation);
+
+	useEffect(() => {
+		rotationRef.current = rotation;
+	});
 
 	const cancelAnimation = useCallback(() => {
 		if (animationRef.current !== null) {
@@ -36,11 +42,7 @@ export function useGlobeAnimation(
 			0
 		];
 
-		let startRotation: [number, number, number] = [0, 0, 0];
-		setRotation((prev) => {
-			startRotation = prev;
-			return prev;
-		});
+		const startRotation = rotationRef.current;
 
 		let dLambda = (targetRotation[0] - startRotation[0]) % 360;
 		if (dLambda < -180) dLambda += 360;

--- a/src/hooks/useGlobeAnimation.ts
+++ b/src/hooks/useGlobeAnimation.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useRef } from "react";
+import { geoCentroid } from "d3-geo";
+import type { CountryFeature, WorldGeoJson } from "@/hooks/useCountryPaths";
+
+const ANIMATION_MS = 750;
+
+export function useGlobeAnimation(
+	selectedCountry: string | null | undefined,
+	geoJson: WorldGeoJson | null,
+	isGlobe: boolean,
+	setRotation: React.Dispatch<React.SetStateAction<[number, number, number]>>
+) {
+	const animationRef = useRef<number | null>(null);
+
+	const cancelAnimation = useCallback(() => {
+		if (animationRef.current !== null) {
+			cancelAnimationFrame(animationRef.current);
+			animationRef.current = null;
+		}
+	}, []);
+
+	useEffect(() => {
+		if (!isGlobe || !selectedCountry || !geoJson) return;
+
+		const feature = geoJson.features.find(
+			(f: CountryFeature) => f.properties.ISO_A2_EH === selectedCountry
+		);
+		if (!feature) return;
+
+		const centroid = geoCentroid(feature);
+		if (isNaN(centroid[0]) || isNaN(centroid[1])) return;
+
+		const targetRotation: [number, number, number] = [
+			-centroid[0],
+			-centroid[1],
+			0
+		];
+
+		let startRotation: [number, number, number] = [0, 0, 0];
+		setRotation((prev) => {
+			startRotation = prev;
+			return prev;
+		});
+
+		let dLambda = (targetRotation[0] - startRotation[0]) % 360;
+		if (dLambda < -180) dLambda += 360;
+		if (dLambda > 180) dLambda -= 360;
+
+		const startTime = performance.now();
+
+		const animate = (time: number) => {
+			const progress = Math.min((time - startTime) / ANIMATION_MS, 1);
+			const ease = 1 - Math.pow(1 - progress, 3);
+
+			setRotation([
+				startRotation[0] + dLambda * ease,
+				startRotation[1] + (targetRotation[1] - startRotation[1]) * ease,
+				0
+			]);
+
+			if (progress < 1) {
+				animationRef.current = requestAnimationFrame(animate);
+			}
+		};
+
+		cancelAnimation();
+		animationRef.current = requestAnimationFrame(animate);
+
+		return cancelAnimation;
+	}, [selectedCountry, geoJson, isGlobe, setRotation, cancelAnimation]);
+
+	return { cancelAnimation };
+}

--- a/src/hooks/useGlobeRotation.ts
+++ b/src/hooks/useGlobeRotation.ts
@@ -29,6 +29,7 @@ export function useGlobeRotation(
 		selectedCountry,
 		geoJson,
 		isGlobe,
+		rotation,
 		setRotation
 	);
 

--- a/src/hooks/useGlobeRotation.ts
+++ b/src/hooks/useGlobeRotation.ts
@@ -1,11 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { geoCentroid } from "d3-geo";
-import type { CountryFeature, WorldGeoJson } from "@/hooks/useCountryPaths";
+import { useCallback, useState } from "react";
+import type { WorldGeoJson } from "@/hooks/useCountryPaths";
 import type { MAP_MODE } from "@/App";
+import { useMapGestures } from "@/hooks/useMapGestures";
+import { useGlobeAnimation } from "@/hooks/useGlobeAnimation";
 
-const DRAG_THRESHOLD_PX = 6;
 const BASE_DRAG_SENSITIVITY = 0.4;
-const ANIMATION_MS = 750;
 
 export function useGlobeRotation(
 	selectedCountry: string | null | undefined,
@@ -19,177 +18,53 @@ export function useGlobeRotation(
 
 	const [rotation, setRotation] = useState<[number, number, number]>([0, 0, 0]);
 	const [pan, setPan] = useState<[number, number]>([0, 0]);
-	const [isDragging, setIsDragging] = useState(false);
 
-	const currentRotationRef = useRef(rotation);
-	const wasDraggingRef = useRef(false);
-	const dragStartRef = useRef<{
-		x: number;
-		y: number;
-		rot: [number, number, number];
-		pan: [number, number];
-		pointerId: number;
-		captured: boolean;
-	} | null>(null);
-	const animationRef = useRef<number | null>(null);
-
-	useEffect(() => {
-		currentRotationRef.current = rotation;
-	}, [rotation]);
-
-	useEffect(() => {
-		if (zoom <= 1) {
-			// eslint-disable-next-line react-hooks/set-state-in-effect
-			setPan([0, 0]);
-		}
-	}, [zoom]);
+	if (zoom <= 1 && (pan[0] !== 0 || pan[1] !== 0)) {
+		setPan([0, 0]);
+	}
 
 	const effectivePan: [number, number] = zoom <= 1 ? [0, 0] : pan;
 
-	const onPointerDown = useCallback(
-		(e: React.PointerEvent) => {
-			if (animationRef.current) cancelAnimationFrame(animationRef.current);
-
-			if (!isGlobe && zoom <= 1) return;
-
-			wasDraggingRef.current = false;
-			dragStartRef.current = {
-				x: e.clientX,
-				y: e.clientY,
-				rot: currentRotationRef.current,
-				pan: effectivePan,
-				pointerId: e.pointerId,
-				captured: false
-			};
-		},
-		[isGlobe, zoom, effectivePan]
+	const { cancelAnimation } = useGlobeAnimation(
+		selectedCountry,
+		geoJson,
+		isGlobe,
+		setRotation
 	);
 
-	const onPointerMove = useCallback(
-		(e: React.PointerEvent) => {
-			if (!dragStartRef.current) return;
-
-			const dx = e.clientX - dragStartRef.current.x;
-			const dy = e.clientY - dragStartRef.current.y;
-
-			if (!wasDraggingRef.current) {
-				if (Math.hypot(dx, dy) < DRAG_THRESHOLD_PX) return;
-
-				wasDraggingRef.current = true;
-				setIsDragging(true);
-
-				if (!dragStartRef.current.captured && e.currentTarget.setPointerCapture) {
-					try {
-						e.currentTarget.setPointerCapture(e.pointerId);
-						dragStartRef.current.captured = true;
-					} catch {
-						// Edge case fallback
-					}
-				}
-			}
-
+	const handleDrag = useCallback(
+		(dx: number, dy: number) => {
 			if (isGlobe) {
 				const sensitivity = BASE_DRAG_SENSITIVITY / zoom;
-				setRotation([
-					dragStartRef.current.rot[0] + dx * sensitivity,
-					Math.max(
-						-90,
-						Math.min(90, dragStartRef.current.rot[1] - dy * sensitivity)
-					),
+				setRotation(([r0, r1]) => [
+					r0 + dx * sensitivity,
+					Math.max(-90, Math.min(90, r1 - dy * sensitivity)),
 					0
 				]);
 			} else {
 				const maxX = Math.max(0, (width * zoom - width) / 2);
 				const maxY = Math.max(0, (height * zoom - height) / 2);
 
-				setPan([
-					Math.max(-maxX, Math.min(maxX, dragStartRef.current.pan[0] + dx)),
-					Math.max(-maxY, Math.min(maxY, dragStartRef.current.pan[1] + dy))
+				setPan(([p0, p1]) => [
+					Math.max(-maxX, Math.min(maxX, p0 + dx)),
+					Math.max(-maxY, Math.min(maxY, p1 + dy))
 				]);
 			}
 		},
 		[isGlobe, zoom, width, height]
 	);
 
-	const onPointerUp = useCallback((e: React.PointerEvent) => {
-		if (dragStartRef.current?.captured) {
-			try {
-				if (
-					e.currentTarget.hasPointerCapture
-					&& e.currentTarget.hasPointerCapture(e.pointerId)
-				) {
-					e.currentTarget.releasePointerCapture(e.pointerId);
-				}
-			} catch (err) {
-				console.warn("Failed to release pointer capture:", err);
-			}
-		}
-
-		dragStartRef.current = null;
-		setIsDragging(false);
-		setTimeout(() => {
-			wasDraggingRef.current = false;
-		}, 100);
-	}, []);
-
-	useEffect(() => {
-		if (!isGlobe || !selectedCountry || !geoJson) return;
-
-		const feature = geoJson.features.find(
-			(f: CountryFeature) => f.properties.ISO_A2_EH === selectedCountry
-		);
-		if (!feature) return;
-
-		const centroid = geoCentroid(feature);
-		if (isNaN(centroid[0]) || isNaN(centroid[1])) return;
-
-		const targetRotation: [number, number, number] = [
-			-centroid[0],
-			-centroid[1],
-			0
-		];
-		const startRotation = currentRotationRef.current;
-
-		let dLambda = (targetRotation[0] - startRotation[0]) % 360;
-		if (dLambda < -180) dLambda += 360;
-		if (dLambda > 180) dLambda -= 360;
-
-		const startTime = performance.now();
-
-		const animate = (time: number) => {
-			const progress = Math.min((time - startTime) / ANIMATION_MS, 1);
-			const ease = 1 - Math.pow(1 - progress, 3);
-
-			setRotation([
-				startRotation[0] + dLambda * ease,
-				startRotation[1] + (targetRotation[1] - startRotation[1]) * ease,
-				0
-			]);
-
-			if (progress < 1) {
-				animationRef.current = requestAnimationFrame(animate);
-			}
-		};
-
-		if (animationRef.current) cancelAnimationFrame(animationRef.current);
-		animationRef.current = requestAnimationFrame(animate);
-
-		return () => {
-			if (animationRef.current) cancelAnimationFrame(animationRef.current);
-		};
-	}, [selectedCountry, geoJson, isGlobe]);
+	const { isDragging, didDrag, gestureHandlers } = useMapGestures({
+		enabled: isGlobe || zoom > 1,
+		onDragStart: cancelAnimation,
+		onDrag: handleDrag
+	});
 
 	return {
 		rotation,
 		pan: effectivePan,
 		isDragging,
-		justDragged: () => wasDraggingRef.current,
-		dragHandlers: {
-			onPointerDown,
-			onPointerMove,
-			onPointerUp,
-			onPointerLeave: onPointerUp,
-			onPointerCancel: onPointerUp
-		}
+		didDrag,
+		dragHandlers: gestureHandlers
 	};
 }

--- a/src/hooks/useMapGestures.ts
+++ b/src/hooks/useMapGestures.ts
@@ -1,0 +1,99 @@
+import { useCallback, useRef, useState } from "react";
+
+const DRAG_THRESHOLD_PX = 6;
+
+interface UseMapGesturesOptions {
+	enabled: boolean;
+	onDrag: (dx: number, dy: number) => void;
+	onDragStart?: () => void;
+	onDragEnd?: () => void;
+}
+
+export function useMapGestures({
+	enabled,
+	onDrag,
+	onDragStart,
+	onDragEnd
+}: UseMapGesturesOptions) {
+	const [isDragging, setIsDragging] = useState(false);
+	const didDragRef = useRef(false);
+	const startPosRef = useRef<{ x: number; y: number } | null>(null);
+	const capturedRef = useRef(false);
+
+	const onPointerDown = useCallback(
+		(e: React.PointerEvent) => {
+			if (!enabled) return;
+
+			didDragRef.current = false;
+			capturedRef.current = false;
+			startPosRef.current = { x: e.clientX, y: e.clientY };
+		},
+		[enabled]
+	);
+
+	const onPointerMove = useCallback(
+		(e: React.PointerEvent) => {
+			if (!startPosRef.current || !enabled) return;
+
+			const dx = e.clientX - startPosRef.current.x;
+			const dy = e.clientY - startPosRef.current.y;
+
+			if (!didDragRef.current) {
+				if (Math.hypot(dx, dy) < DRAG_THRESHOLD_PX) return;
+
+				didDragRef.current = true;
+				setIsDragging(true);
+				onDragStart?.();
+
+				if (e.currentTarget.setPointerCapture) {
+					try {
+						e.currentTarget.setPointerCapture(e.pointerId);
+						capturedRef.current = true;
+					} catch (err) {
+						console.warn("Failed to set pointer capture:", err);
+					}
+				}
+			}
+
+			onDrag(dx, dy);
+			startPosRef.current = { x: e.clientX, y: e.clientY };
+		},
+		[enabled, onDrag, onDragStart]
+	);
+
+	const onPointerUp = useCallback(
+		(e: React.PointerEvent) => {
+			if (startPosRef.current) {
+				if (
+					capturedRef.current
+					&& e.currentTarget.hasPointerCapture?.(e.pointerId)
+				) {
+					try {
+						e.currentTarget.releasePointerCapture(e.pointerId);
+					} catch (err) {
+						console.warn("Failed to release pointer capture:", err);
+					}
+				}
+				if (didDragRef.current) {
+					onDragEnd?.();
+				}
+			}
+
+			startPosRef.current = null;
+			setIsDragging(false);
+		},
+		[onDragEnd]
+	);
+
+	return {
+		isDragging,
+		didDrag: () => didDragRef.current,
+		gestureHandlers: {
+			onPointerDown,
+			onPointerMove,
+			onPointerUp,
+			onPointerLeave: onPointerUp,
+			onPointerCancel: onPointerUp
+		}
+	};
+}

--- a/src/hooks/useMapGestures.ts
+++ b/src/hooks/useMapGestures.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 const DRAG_THRESHOLD_PX = 6;
 
@@ -19,16 +19,29 @@ export function useMapGestures({
 	const didDragRef = useRef(false);
 	const startPosRef = useRef<{ x: number; y: number } | null>(null);
 	const capturedRef = useRef(false);
+	const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	const clearResetTimer = useCallback(() => {
+		if (resetTimerRef.current !== null) {
+			clearTimeout(resetTimerRef.current);
+			resetTimerRef.current = null;
+		}
+	}, []);
+
+	useEffect(() => {
+		return () => clearResetTimer();
+	}, [clearResetTimer]);
 
 	const onPointerDown = useCallback(
 		(e: React.PointerEvent) => {
 			if (!enabled) return;
 
+			clearResetTimer();
 			didDragRef.current = false;
 			capturedRef.current = false;
 			startPosRef.current = { x: e.clientX, y: e.clientY };
 		},
-		[enabled]
+		[enabled, clearResetTimer]
 	);
 
 	const onPointerMove = useCallback(
@@ -76,13 +89,18 @@ export function useMapGestures({
 				}
 				if (didDragRef.current) {
 					onDragEnd?.();
+
+					clearResetTimer();
+					resetTimerRef.current = setTimeout(() => {
+						didDragRef.current = false;
+					}, 0);
 				}
 			}
 
 			startPosRef.current = null;
 			setIsDragging(false);
 		},
-		[onDragEnd]
+		[onDragEnd, clearResetTimer]
 	);
 
 	return {

--- a/src/hooks/useMapGestures.ts
+++ b/src/hooks/useMapGestures.ts
@@ -22,7 +22,8 @@ export function useMapGestures({
 
 	const onPointerDown = useCallback(
 		(e: React.PointerEvent) => {
-			if (!enabled) return;
+			if (!enabled || e.button !== 0) return;
+
 			didDragRef.current = false;
 			capturedRef.current = false;
 			startPosRef.current = { x: e.clientX, y: e.clientY };

--- a/src/hooks/useMapGestures.ts
+++ b/src/hooks/useMapGestures.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 const DRAG_THRESHOLD_PX = 6;
 
@@ -19,29 +19,15 @@ export function useMapGestures({
 	const didDragRef = useRef(false);
 	const startPosRef = useRef<{ x: number; y: number } | null>(null);
 	const capturedRef = useRef(false);
-	const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-	const clearResetTimer = useCallback(() => {
-		if (resetTimerRef.current !== null) {
-			clearTimeout(resetTimerRef.current);
-			resetTimerRef.current = null;
-		}
-	}, []);
-
-	useEffect(() => {
-		return () => clearResetTimer();
-	}, [clearResetTimer]);
 
 	const onPointerDown = useCallback(
 		(e: React.PointerEvent) => {
 			if (!enabled) return;
-
-			clearResetTimer();
 			didDragRef.current = false;
 			capturedRef.current = false;
 			startPosRef.current = { x: e.clientX, y: e.clientY };
 		},
-		[enabled, clearResetTimer]
+		[enabled]
 	);
 
 	const onPointerMove = useCallback(
@@ -89,19 +75,21 @@ export function useMapGestures({
 				}
 				if (didDragRef.current) {
 					onDragEnd?.();
-
-					clearResetTimer();
-					resetTimerRef.current = setTimeout(() => {
-						didDragRef.current = false;
-					}, 0);
 				}
 			}
-
 			startPosRef.current = null;
 			setIsDragging(false);
 		},
-		[onDragEnd, clearResetTimer]
+		[onDragEnd]
 	);
+
+	const onClickCapture = useCallback((e: React.MouseEvent) => {
+		if (didDragRef.current) {
+			e.stopPropagation();
+			e.preventDefault();
+			didDragRef.current = false;
+		}
+	}, []);
 
 	return {
 		isDragging,
@@ -111,7 +99,8 @@ export function useMapGestures({
 			onPointerMove,
 			onPointerUp,
 			onPointerLeave: onPointerUp,
-			onPointerCancel: onPointerUp
+			onPointerCancel: onPointerUp,
+			onClickCapture
 		}
 	};
 }


### PR DESCRIPTION
This PR splits `useGlobeRotation` into isolated `useMapGestures` and `useGlobeAnimation` custom hooks to improve code maintainability, separate concerns, and handle drag-versus-click detection cleanly.

**Changes**

* [x] **Refactor:** Created `useMapGestures` hook to encapsulate pointer capture, threshold calculations, and drag gesture lifecycles.
* [x] **Refactor:** Created `useGlobeAnimation` hook to isolate country-centroid rotation math and animation frame management.
* [x] **Refactor:** Simplified `useGlobeRotation` to act purely as an orchestrator composing gestures, animations, and pan limits.
* [x] **Fix:** Exposed `didDrag` state through the hook chain to suppress country click selections in `WorldMap` when completing a map pan.
