### PR TITLE
refactor(map): move audience selection menu to top left overlay dock

### DIFF
--- a/.changeset/slick-rocks-walk.md
+++ b/.changeset/slick-rocks-walk.md
@@ -1,0 +1,5 @@
+---
+"audience-atlas": minor
+---
+
+refactor(map): move audience selection menu to bottom-left overlay dock

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,12 @@ import { useAudience } from "./hooks/useAudience";
 import { useElementSize } from "./hooks/useElementSize";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { Button } from "@/components/ui/button";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger
+} from "@/components/ui/dropdown-menu";
 import {
 	Sheet,
 	SheetContent,
@@ -22,6 +27,7 @@ import {
 	AlertTriangle,
 	ArrowRightLeft,
 	BarChart3,
+	Filter,
 	List,
 	Loader2,
 	MapIcon,
@@ -201,7 +207,6 @@ export default function App() {
 										open={sheetOpen}
 										onOpenChange={(open) => {
 											setSheetOpen(open);
-											if (!open) dispatch({ type: "SET_COUNTRY", payload: null });
 										}}
 										modal={false}>
 										<SheetTrigger asChild>
@@ -302,26 +307,34 @@ export default function App() {
 				{status === "success" && currentAudience && (
 					<div className='relative flex w-full min-h-0 flex-1 items-stretch overflow-hidden'>
 						<div ref={mapContainerRef} className='relative flex-1 overflow-hidden'>
-							<div className='absolute left-1/2 top-4 z-20 -translate-x-1/2 max-w-[calc(100vw-2rem)] overflow-x-auto rounded-full border border-border/60 bg-background/80 p-1 shadow-lg backdrop-blur-md sm:top-8'>
-								<Tabs
-									value={audienceType}
-									onValueChange={(v) =>
-										dispatch({
-											type: "SET_AUDIENCE_TYPE",
-											payload: v as AudienceType
-										})
-									}>
-									<TabsList className='h-9 bg-transparent sm:h-10'>
+							<div className='absolute top-6 left-6 z-20'>
+								<DropdownMenu>
+									<DropdownMenuTrigger asChild>
+										<Button
+											variant='secondary'
+											className='h-9 gap-2 rounded-full border border-border/40 bg-background/60 px-4 text-xs font-medium shadow-lg backdrop-blur-xl hover:bg-background/80'>
+											<Filter className='h-3.5 w-3.5' />
+											{AUDIENCE_TABS.find((t) => t.value === audienceType)?.label}
+										</Button>
+									</DropdownMenuTrigger>
+									<DropdownMenuContent
+										align='start'
+										className='w-40 rounded-xl bg-background/95 backdrop-blur-xl'>
 										{AUDIENCE_TABS.map((tab) => (
-											<TabsTrigger
+											<DropdownMenuItem
 												key={tab.value}
-												value={tab.value}
-												className='rounded-full px-4 text-xs font-medium sm:px-6 sm:text-sm data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:shadow-sm'>
+												onClick={() =>
+													dispatch({
+														type: "SET_AUDIENCE_TYPE",
+														payload: tab.value as AudienceType
+													})
+												}
+												className={`text-xs ${audienceType === tab.value ? "font-bold text-primary" : "text-muted-foreground"}`}>
 												{tab.label}
-											</TabsTrigger>
+											</DropdownMenuItem>
 										))}
-									</TabsList>
-								</Tabs>
+									</DropdownMenuContent>
+								</DropdownMenu>
 							</div>
 
 							{size && size.width > 0 && size.height > 0 ?

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,262 @@
+import * as React from "react";
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Tick02Icon, ArrowRight01Icon } from "@hugeicons/core-free-icons";
+
+function DropdownMenu({
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+	return <DropdownMenuPrimitive.Root data-slot='dropdown-menu' {...props} />;
+}
+
+function DropdownMenuPortal({
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+	return (
+		<DropdownMenuPrimitive.Portal data-slot='dropdown-menu-portal' {...props} />
+	);
+}
+
+function DropdownMenuTrigger({
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+	return (
+		<DropdownMenuPrimitive.Trigger data-slot='dropdown-menu-trigger' {...props} />
+	);
+}
+
+function DropdownMenuContent({
+	className,
+	align = "start",
+	sideOffset = 4,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+	return (
+		<DropdownMenuPrimitive.Portal>
+			<DropdownMenuPrimitive.Content
+				data-slot='dropdown-menu-content'
+				sideOffset={sideOffset}
+				align={align}
+				className={cn(
+					"z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+					className
+				)}
+				{...props}
+			/>
+		</DropdownMenuPrimitive.Portal>
+	);
+}
+
+function DropdownMenuGroup({
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+	return <DropdownMenuPrimitive.Group data-slot='dropdown-menu-group' {...props} />;
+}
+
+function DropdownMenuItem({
+	className,
+	inset,
+	variant = "default",
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+	inset?: boolean;
+	variant?: "default" | "destructive";
+}) {
+	return (
+		<DropdownMenuPrimitive.Item
+			data-slot='dropdown-menu-item'
+			data-inset={inset}
+			data-variant={variant}
+			className={cn(
+				"group/dropdown-menu-item relative flex min-h-7 cursor-default items-center gap-2 rounded-md px-2 py-1 text-xs/relaxed outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7.5 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5 data-[variant=destructive]:*:[svg]:text-destructive",
+				className
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DropdownMenuCheckboxItem({
+	className,
+	children,
+	checked,
+	inset,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem> & {
+	inset?: boolean;
+}) {
+	return (
+		<DropdownMenuPrimitive.CheckboxItem
+			data-slot='dropdown-menu-checkbox-item'
+			data-inset={inset}
+			className={cn(
+				"relative flex min-h-7 cursor-default items-center gap-2 rounded-md py-1.5 pr-8 pl-2 text-xs outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7.5 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+				className
+			)}
+			checked={checked}
+			{...props}>
+			<span
+				className='pointer-events-none absolute right-2 flex items-center justify-center'
+				data-slot='dropdown-menu-checkbox-item-indicator'>
+				<DropdownMenuPrimitive.ItemIndicator>
+					<HugeiconsIcon icon={Tick02Icon} strokeWidth={2} />
+				</DropdownMenuPrimitive.ItemIndicator>
+			</span>
+			{children}
+		</DropdownMenuPrimitive.CheckboxItem>
+	);
+}
+
+function DropdownMenuRadioGroup({
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+	return (
+		<DropdownMenuPrimitive.RadioGroup
+			data-slot='dropdown-menu-radio-group'
+			{...props}
+		/>
+	);
+}
+
+function DropdownMenuRadioItem({
+	className,
+	children,
+	inset,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem> & {
+	inset?: boolean;
+}) {
+	return (
+		<DropdownMenuPrimitive.RadioItem
+			data-slot='dropdown-menu-radio-item'
+			data-inset={inset}
+			className={cn(
+				"relative flex min-h-7 cursor-default items-center gap-2 rounded-md py-1.5 pr-8 pl-2 text-xs outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7.5 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+				className
+			)}
+			{...props}>
+			<span
+				className='pointer-events-none absolute right-2 flex items-center justify-center'
+				data-slot='dropdown-menu-radio-item-indicator'>
+				<DropdownMenuPrimitive.ItemIndicator>
+					<HugeiconsIcon icon={Tick02Icon} strokeWidth={2} />
+				</DropdownMenuPrimitive.ItemIndicator>
+			</span>
+			{children}
+		</DropdownMenuPrimitive.RadioItem>
+	);
+}
+
+function DropdownMenuLabel({
+	className,
+	inset,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+	inset?: boolean;
+}) {
+	return (
+		<DropdownMenuPrimitive.Label
+			data-slot='dropdown-menu-label'
+			data-inset={inset}
+			className={cn(
+				"px-2 py-1.5 text-xs text-muted-foreground data-inset:pl-7.5",
+				className
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DropdownMenuSeparator({
+	className,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+	return (
+		<DropdownMenuPrimitive.Separator
+			data-slot='dropdown-menu-separator'
+			className={cn("-mx-1 my-1 h-px bg-border/50", className)}
+			{...props}
+		/>
+	);
+}
+
+function DropdownMenuShortcut({
+	className,
+	...props
+}: React.ComponentProps<"span">) {
+	return (
+		<span
+			data-slot='dropdown-menu-shortcut'
+			className={cn(
+				"ml-auto text-[0.625rem] tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
+				className
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DropdownMenuSub({
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+	return <DropdownMenuPrimitive.Sub data-slot='dropdown-menu-sub' {...props} />;
+}
+
+function DropdownMenuSubTrigger({
+	className,
+	inset,
+	children,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+	inset?: boolean;
+}) {
+	return (
+		<DropdownMenuPrimitive.SubTrigger
+			data-slot='dropdown-menu-sub-trigger'
+			data-inset={inset}
+			className={cn(
+				"flex min-h-7 cursor-default items-center gap-2 rounded-md px-2 py-1 text-xs outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7.5 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+				className
+			)}
+			{...props}>
+			{children}
+			<HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={2} className='ml-auto' />
+		</DropdownMenuPrimitive.SubTrigger>
+	);
+}
+
+function DropdownMenuSubContent({
+	className,
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+	return (
+		<DropdownMenuPrimitive.SubContent
+			data-slot='dropdown-menu-sub-content'
+			className={cn(
+				"z-50 min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+				className
+			)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	DropdownMenu,
+	DropdownMenuPortal,
+	DropdownMenuTrigger,
+	DropdownMenuContent,
+	DropdownMenuGroup,
+	DropdownMenuLabel,
+	DropdownMenuItem,
+	DropdownMenuCheckboxItem,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuSeparator,
+	DropdownMenuShortcut,
+	DropdownMenuSub,
+	DropdownMenuSubTrigger,
+	DropdownMenuSubContent
+};


### PR DESCRIPTION
Relocates the floating audience selection switcher from the top center viewport to the top left overlay dock. This clears the central map canvas to prevent hiding high density regions like North America and Europe.

- [x] Shift tab controller to bottom-left stacked layout above map overview metrics.
- [x] Apply micro pill typography and reduce padding to shrink control footprint.
- [x] Increase glassmorphism blur and lower background opacity to keep map lines visible.
- [x] Retain responsive centering for mobile viewports.