### PR TITLE
chore: reinitialize shadcn UI, remove unused packages, and update vitest

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://ui.shadcn.com/schema.json",
-	"style": "radix-mira",
+	"style": "radix-rhea",
 	"rsc": false,
 	"tsx": true,
 	"tailwind": {
@@ -10,7 +10,7 @@
 		"cssVariables": true,
 		"prefix": ""
 	},
-	"iconLibrary": "hugeicons",
+	"iconLibrary": "lucide",
 	"rtl": false,
 	"aliases": {
 		"components": "@/components",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"@tanstack/react-virtual": "^3.14.7",
 				"class-variance-authority": "^0.7.1",
 				"clsx": "^2.1.1",
+				"cn": "^0.2.6",
 				"country-flag-icons": "^1.6.20",
 				"d3": "^7.9.0",
 				"html-to-image": "^1.11.13",
@@ -25,10 +26,9 @@
 				"radix-ui": "^1.4.3",
 				"react": "^19.2.5",
 				"react-dom": "^19.2.5",
-				"shadcn": "^4.13.0",
+				"shadcn": "^4.21.0",
 				"tailwind-merge": "^3.6.0",
 				"tailwindcss": "^4.3.0",
-				"topojson-client": "^3.1.0",
 				"tw-animate-css": "^1.4.0"
 			},
 			"devDependencies": {
@@ -47,7 +47,7 @@
 				"@types/react-dom": "^19.2.3",
 				"@types/topojson-client": "^3.1.5",
 				"@vitejs/plugin-react": "^6.0.1",
-				"@vitest/coverage-v8": "^4.1.8",
+				"@vitest/coverage-v8": "^4.1.11",
 				"eslint": "^10.2.1",
 				"eslint-plugin-react-hooks": "^7.1.1",
 				"eslint-plugin-react-refresh": "^0.5.2",
@@ -61,8 +61,7 @@
 				"typescript": "~6.0.2",
 				"typescript-eslint": "^8.58.2",
 				"vite": "^8.0.10",
-				"vitest": "^4.1.8",
-				"zod": "^4.3.6"
+				"vitest": "^4.1.11"
 			}
 		},
 		"node_modules/@asamuzakjp/css-color": {
@@ -450,10 +449,6 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@babel/core/node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.5.5",
-			"license": "MIT"
-		},
 		"node_modules/@babel/core/node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.31",
 			"license": "MIT",
@@ -461,10 +456,6 @@
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
-		},
-		"node_modules/@babel/core/node_modules/convert-source-map": {
-			"version": "2.0.0",
-			"license": "MIT"
 		},
 		"node_modules/@babel/core/node_modules/gensync": {
 			"version": "1.0.0-beta.2",
@@ -751,10 +742,6 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@babel/plugin-transform-typescript/node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.5.5",
-			"license": "MIT"
-		},
 		"node_modules/@babel/plugin-transform-typescript/node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.31",
 			"license": "MIT",
@@ -952,10 +939,6 @@
 			"engines": {
 				"node": ">=6.0.0"
 			}
-		},
-		"node_modules/@babel/preset-typescript/node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.5.5",
-			"license": "MIT"
 		},
 		"node_modules/@babel/preset-typescript/node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.31",
@@ -1768,14 +1751,6 @@
 				"url": "https://ko-fi.com/dangreen"
 			}
 		},
-		"node_modules/@commitlint/read/node_modules/escalade": {
-			"version": "3.2.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/@commitlint/read/node_modules/git-raw-commits": {
 			"version": "5.0.1",
 			"dev": true,
@@ -2373,6 +2348,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+			"integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+			"license": "MIT"
 		},
 		"node_modules/@manypkg/find-root": {
 			"version": "3.1.0",
@@ -5547,6 +5528,13 @@
 			"version": "1.0.1",
 			"license": "MIT"
 		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@tailwindcss/node": {
 			"version": "4.3.0",
 			"license": "MIT",
@@ -5582,10 +5570,6 @@
 			"engines": {
 				"node": ">=6.0.0"
 			}
-		},
-		"node_modules/@tailwindcss/node/node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.5.5",
-			"license": "MIT"
 		},
 		"node_modules/@tailwindcss/node/node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.31",
@@ -5660,13 +5644,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@tailwindcss/node/node_modules/magic-string": {
-			"version": "0.30.21",
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
 		"node_modules/@tailwindcss/node/node_modules/source-map-js": {
@@ -6030,6 +6007,17 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/chai": {
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*",
+				"assertion-error": "^2.0.1"
+			}
+		},
 		"node_modules/@types/d3": {
 			"version": "7.4.3",
 			"resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
@@ -6315,7 +6303,18 @@
 			}
 		},
 		"node_modules/@types/deep-eql": {
-			"dev": true
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/geojson": {
 			"version": "7946.0.16",
@@ -6853,12 +6852,14 @@
 			}
 		},
 		"node_modules/@vitest/coverage-v8": {
-			"version": "4.1.8",
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.11.tgz",
+			"integrity": "sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@bcoe/v8-coverage": "^1.0.2",
-				"@vitest/utils": "4.1.8",
+				"@vitest/utils": "4.1.11",
 				"ast-v8-to-istanbul": "^1.0.0",
 				"istanbul-lib-coverage": "^3.2.2",
 				"istanbul-lib-report": "^3.0.1",
@@ -6872,8 +6873,8 @@
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"@vitest/browser": "4.1.8",
-				"vitest": "4.1.8"
+				"@vitest/browser": "4.1.11",
+				"vitest": "4.1.11"
 			},
 			"peerDependenciesMeta": {
 				"@vitest/browser": {
@@ -6881,34 +6882,118 @@
 				}
 			}
 		},
-		"node_modules/@vitest/utils": {
-			"version": "4.1.8",
+		"node_modules/@vitest/expect": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+			"integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.8",
+				"@standard-schema/spec": "^1.1.0",
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "4.1.11",
+				"@vitest/utils": "4.1.11",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+			"integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "4.1.11",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.21"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+			"integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^3.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+			"integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "4.1.11",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+			"integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.11",
+				"@vitest/utils": "4.1.11",
+				"magic-string": "^0.30.21",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+			"integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+			"integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "4.1.11",
 				"convert-source-map": "^2.0.0",
 				"tinyrainbow": "^3.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
-		},
-		"node_modules/@vitest/utils/node_modules/@vitest/pretty-format": {
-			"version": "4.1.8",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"tinyrainbow": "^3.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/@vitest/utils/node_modules/convert-source-map": {
-			"version": "2.0.0",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/ansi-colors": {
 			"version": "4.1.3",
@@ -6939,6 +7024,16 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/ast-v8-to-istanbul": {
 			"version": "1.0.3",
 			"dev": true,
@@ -6957,11 +7052,6 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/ast-v8-to-istanbul/node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.5.5",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/ast-v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.31",
 			"dev": true,
@@ -6969,19 +7059,6 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
-			}
-		},
-		"node_modules/ast-v8-to-istanbul/node_modules/@types/estree": {
-			"version": "1.0.9",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
-			"version": "3.0.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "^1.0.0"
 			}
 		},
 		"node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
@@ -6996,6 +7073,18 @@
 			"license": "MIT",
 			"engines": {
 				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/baseline-browser-mapping": {
+			"version": "2.11.22",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.22.tgz",
+			"integrity": "sha512-pWc4w51fBFd7mav43/zKRC+RI6f4yfzQoVlfvE8dECePyfkn1bzLp01Fj0QACcyCZyFhiEMyD2qScfKRWgWibA==",
+			"license": "Apache-2.0",
+			"bin": {
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/before-after-hook": {
@@ -7057,7 +7146,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.28.2",
+			"version": "4.28.9",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+			"integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -7074,91 +7165,17 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"baseline-browser-mapping": "^2.10.12",
-				"caniuse-lite": "^1.0.30001782",
-				"electron-to-chromium": "^1.5.328",
-				"node-releases": "^2.0.36",
-				"update-browserslist-db": "^1.2.3"
+				"baseline-browser-mapping": "^2.11.20",
+				"caniuse-lite": "^1.0.30001810",
+				"electron-to-chromium": "^1.5.420",
+				"node-releases": "^2.0.54",
+				"update-browserslist-db": "^1.3.2"
 			},
 			"bin": {
 				"browserslist": "cli.js"
 			},
 			"engines": {
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-			}
-		},
-		"node_modules/browserslist/node_modules/baseline-browser-mapping": {
-			"version": "2.10.34",
-			"license": "Apache-2.0",
-			"bin": {
-				"baseline-browser-mapping": "dist/cli.cjs"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/browserslist/node_modules/caniuse-lite": {
-			"version": "1.0.30001797",
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/browserslist"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "CC-BY-4.0"
-		},
-		"node_modules/browserslist/node_modules/electron-to-chromium": {
-			"version": "1.5.368",
-			"license": "ISC"
-		},
-		"node_modules/browserslist/node_modules/escalade": {
-			"version": "3.2.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/browserslist/node_modules/node-releases": {
-			"version": "2.0.47",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/browserslist/node_modules/update-browserslist-db": {
-			"version": "1.2.3",
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/browserslist"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/funding/github/npm/browserslist"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"escalade": "^3.2.0",
-				"picocolors": "^1.1.1"
-			},
-			"bin": {
-				"update-browserslist-db": "cli.js"
-			},
-			"peerDependencies": {
-				"browserslist": ">= 4.21.0"
 			}
 		},
 		"node_modules/bytes": {
@@ -7209,6 +7226,36 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/caniuse-lite": {
+			"version": "1.0.30001810",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+			"integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "CC-BY-4.0"
+		},
+		"node_modules/chai": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/class-variance-authority": {
 			"version": "0.7.1",
 			"license": "Apache-2.0",
@@ -7224,6 +7271,18 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/cn": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/cn/-/cn-0.2.6.tgz",
+			"integrity": "sha512-+i4L0zUGgRcEnhsxueVrP7iBGxBx5iD0WOTYg1MwFEu2ZyCmH5Ov2V1cul2Ht5UchRQQgftCf4be/RxspuW6QQ==",
+			"license": "MIT",
+			"bin": {
+				"cn": "bin/cn.mjs"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/commander": {
@@ -7289,6 +7348,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"license": "MIT"
 		},
 		"node_modules/cookie": {
 			"version": "1.1.1",
@@ -7957,6 +8022,12 @@
 			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
 			"license": "MIT"
 		},
+		"node_modules/electron-to-chromium": {
+			"version": "1.5.427",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.427.tgz",
+			"integrity": "sha512-n14zb3FdsChZ2BNobqNHAJMcP3ifFv4paox2LvCrfVAQcqGiSURgbJl+PfMpHVCNFkStnNc+RRVtPBTVW5PDgw==",
+			"license": "ISC"
+		},
 		"node_modules/enquirer": {
 			"version": "2.4.1",
 			"license": "MIT",
@@ -8003,6 +8074,13 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/es-module-lexer": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+			"integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -8013,6 +8091,15 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/eslint": {
@@ -8244,11 +8331,6 @@
 		},
 		"node_modules/eslint/node_modules/@types/esrecurse": {
 			"version": "4.3.1",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/eslint/node_modules/@types/estree": {
-			"version": "1.0.9",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -8739,6 +8821,16 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
 		"node_modules/execa": {
 			"version": "9.6.1",
 			"license": "MIT",
@@ -8981,6 +9073,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/expect-type": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+			"integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
 		"node_modules/fast-glob": {
 			"version": "3.3.3",
 			"license": "MIT",
@@ -9188,9 +9290,9 @@
 			}
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+			"integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
 			"funding": [
 				{
 					"type": "github",
@@ -9386,9 +9488,9 @@
 			"license": "MIT"
 		},
 		"node_modules/hono": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
-			"integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
+			"version": "4.13.7",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+			"integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.9.0"
@@ -9614,9 +9716,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+			"integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
 			"funding": [
 				{
 					"type": "github",
@@ -10283,6 +10385,15 @@
 				"lz-string": "bin/bin.js"
 			}
 		},
+		"node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
 		"node_modules/magicast": {
 			"version": "0.5.3",
 			"dev": true,
@@ -10477,14 +10588,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/msw/node_modules/escalade": {
-			"version": "3.2.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/msw/node_modules/get-caller-file": {
 			"version": "2.0.5",
 			"dev": true,
@@ -10600,6 +10703,15 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
+		"node_modules/node-releases": {
+			"version": "2.0.55",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.55.tgz",
+			"integrity": "sha512-mIrE/Cw9y+9Au6dS5vDKDhQza9YvG6w+ZrS6X+ZzA7yFW/soAeaups4Qzn1bL6g5FVy8WtP79+0j82oPIbqRjQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/object-inspect": {
 			"version": "1.13.4",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -10613,7 +10725,9 @@
 			}
 		},
 		"node_modules/obug": {
-			"version": "2.1.2",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.2.1.tgz",
+			"integrity": "sha512-XrsrhT5sybtKI6wakr2SPOlGZWWYbUXZ7a0jT8/QOeAPau+1X/bSegNe5YR75oJmEZQbKningirmGOEJCIk61Q==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/sxzz",
@@ -11033,6 +11147,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"license": "ISC"
@@ -11104,7 +11225,9 @@
 			}
 		},
 		"node_modules/postcss-selector-parser": {
-			"version": "7.1.1",
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.6.tgz",
+			"integrity": "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==",
 			"license": "MIT",
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -11205,9 +11328,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.15.3",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-			"integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+			"integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"es-define-property": "^1.0.1",
@@ -11449,9 +11572,9 @@
 			"license": "ISC"
 		},
 		"node_modules/shadcn": {
-			"version": "4.13.0",
-			"resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.13.0.tgz",
-			"integrity": "sha512-5fuJ4jI/GcPeA/iTL4cJivCZuYQGXz/N3bIzyd+Gd/FM6xUCy2MxGG+LaDQuw2cjNy9zGPSFPTEmI048UwPTZA==",
+			"version": "4.21.0",
+			"resolved": "https://registry.npmjs.org/shadcn/-/shadcn-4.21.0.tgz",
+			"integrity": "sha512-UU2mFNusW8C5rvadKdH69vERYZqUlOOlXBcf0MYhYLdTGP6DPti7X4qovCu+RTfCqsAgq/T+YfE0Vnttxh9aiw==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/core": "^7.28.0",
@@ -11462,6 +11585,7 @@
 				"@modelcontextprotocol/sdk": "^1.26.0",
 				"@types/validate-npm-package-name": "^4.0.2",
 				"browserslist": "^4.26.2",
+				"cn": "^0.2.4",
 				"commander": "^14.0.0",
 				"cosmiconfig": "^9.0.0",
 				"dedent": "^1.6.0",
@@ -11478,8 +11602,8 @@
 				"postcss-selector-parser": "^7.1.0",
 				"prompts": "^2.4.2",
 				"recast": "^0.23.11",
+				"socks": "^2.8.8",
 				"stringify-object": "^5.0.0",
-				"tailwind-merge": "^3.0.1",
 				"ts-morph": "^26.0.0",
 				"tsconfig-paths": "^4.2.0",
 				"undici": "^7.27.2",
@@ -11619,10 +11743,48 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
 			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+			"license": "MIT"
+		},
+		"node_modules/smart-buffer": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks": {
+			"version": "2.8.10",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.10.tgz",
+			"integrity": "sha512-e0VyvkVTwVYViNovRkZ9aodhxVlyoMn7eJhVUPxZ+eK9P/7CBkxvvsBOHqFPEH416726W8tLXXXjKwqgTErrCQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ip-address": "^10.1.1",
+				"smart-buffer": "^4.2.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/statuses": {
@@ -11633,7 +11795,9 @@
 			}
 		},
 		"node_modules/std-env": {
-			"version": "4.1.0",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+			"integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -11712,6 +11876,13 @@
 			"version": "4.3.0",
 			"license": "MIT"
 		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/tinyexec": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
@@ -11739,7 +11910,9 @@
 			}
 		},
 		"node_modules/tinyrainbow": {
-			"version": "3.1.0",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+			"integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -11754,26 +11927,6 @@
 			"engines": {
 				"node": ">=0.6"
 			}
-		},
-		"node_modules/topojson-client": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
-			"integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
-			"license": "ISC",
-			"dependencies": {
-				"commander": "2"
-			},
-			"bin": {
-				"topo2geo": "bin/topo2geo",
-				"topomerge": "bin/topomerge",
-				"topoquantize": "bin/topoquantize"
-			}
-		},
-		"node_modules/topojson-client/node_modules/commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"license": "MIT"
 		},
 		"node_modules/tough-cookie": {
 			"version": "6.0.1",
@@ -12010,6 +12163,36 @@
 				"url": "https://github.com/sponsors/kettanaito"
 			}
 		},
+		"node_modules/update-browserslist-db": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.3.tgz",
+			"integrity": "sha512-pJ2sYawQS0R/WI928Gj5GlPhTGzbMelq0+4INtSYNDV9ErKJcX6xjGWkoG/VnB3dpUm00zALaqkrUD77pO5TDQ==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"escalade": "^3.2.0",
+				"picocolors": "^1.1.1"
+			},
+			"bin": {
+				"update-browserslist-db": "cli.js"
+			},
+			"peerDependencies": {
+				"browserslist": ">= 4.21.0"
+			}
+		},
 		"node_modules/validate-npm-package-name": {
 			"version": "7.0.2",
 			"license": "ISC",
@@ -12211,17 +12394,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.1.8",
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+			"integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.1.8",
-				"@vitest/mocker": "4.1.8",
-				"@vitest/pretty-format": "4.1.8",
-				"@vitest/runner": "4.1.8",
-				"@vitest/snapshot": "4.1.8",
-				"@vitest/spy": "4.1.8",
-				"@vitest/utils": "4.1.8",
+				"@vitest/expect": "4.1.11",
+				"@vitest/mocker": "4.1.11",
+				"@vitest/pretty-format": "4.1.11",
+				"@vitest/runner": "4.1.11",
+				"@vitest/snapshot": "4.1.11",
+				"@vitest/spy": "4.1.11",
+				"@vitest/utils": "4.1.11",
 				"es-module-lexer": "^2.0.0",
 				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
@@ -12249,12 +12434,12 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.8",
-				"@vitest/browser-preview": "4.1.8",
-				"@vitest/browser-webdriverio": "4.1.8",
-				"@vitest/coverage-istanbul": "4.1.8",
-				"@vitest/coverage-v8": "4.1.8",
-				"@vitest/ui": "4.1.8",
+				"@vitest/browser-playwright": "4.1.11",
+				"@vitest/browser-preview": "4.1.11",
+				"@vitest/browser-webdriverio": "4.1.11",
+				"@vitest/coverage-istanbul": "4.1.11",
+				"@vitest/coverage-v8": "4.1.11",
+				"@vitest/ui": "4.1.11",
 				"happy-dom": "*",
 				"jsdom": "*",
 				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -12296,196 +12481,6 @@
 				"vite": {
 					"optional": false
 				}
-			}
-		},
-		"node_modules/vitest/node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.5.5",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/vitest/node_modules/@standard-schema/spec": {
-			"version": "1.1.0",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/vitest/node_modules/@types/chai": {
-			"version": "5.2.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/deep-eql": "*",
-				"assertion-error": "^2.0.1"
-			}
-		},
-		"node_modules/vitest/node_modules/@types/estree": {
-			"version": "1.0.9",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/vitest/node_modules/@vitest/expect": {
-			"version": "4.1.8",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@standard-schema/spec": "^1.1.0",
-				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.8",
-				"@vitest/utils": "4.1.8",
-				"chai": "^6.2.2",
-				"tinyrainbow": "^3.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/vitest/node_modules/@vitest/mocker": {
-			"version": "4.1.8",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/spy": "4.1.8",
-				"estree-walker": "^3.0.3",
-				"magic-string": "^0.30.21"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			},
-			"peerDependencies": {
-				"msw": "^2.4.9",
-				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			},
-			"peerDependenciesMeta": {
-				"msw": {
-					"optional": true
-				},
-				"vite": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/vitest/node_modules/@vitest/pretty-format": {
-			"version": "4.1.8",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"tinyrainbow": "^3.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/vitest/node_modules/@vitest/runner": {
-			"version": "4.1.8",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/utils": "4.1.8",
-				"pathe": "^2.0.3"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/vitest/node_modules/@vitest/snapshot": {
-			"version": "4.1.8",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@vitest/pretty-format": "4.1.8",
-				"@vitest/utils": "4.1.8",
-				"magic-string": "^0.30.21",
-				"pathe": "^2.0.3"
-			},
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/vitest/node_modules/@vitest/spy": {
-			"version": "4.1.8",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://opencollective.com/vitest"
-			}
-		},
-		"node_modules/vitest/node_modules/assertion-error": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/vitest/node_modules/chai": {
-			"version": "6.2.2",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/es-module-lexer": {
-			"version": "2.1.0",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/vitest/node_modules/estree-walker": {
-			"version": "3.0.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "^1.0.0"
-			}
-		},
-		"node_modules/vitest/node_modules/expect-type": {
-			"version": "1.3.0",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
-		"node_modules/vitest/node_modules/magic-string": {
-			"version": "0.30.21",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.5.5"
-			}
-		},
-		"node_modules/vitest/node_modules/pathe": {
-			"version": "2.0.3",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/vitest/node_modules/siginfo": {
-			"version": "2.0.0",
-			"dev": true,
-			"license": "ISC"
-		},
-		"node_modules/vitest/node_modules/stackback": {
-			"version": "0.0.2",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/vitest/node_modules/tinybench": {
-			"version": "2.9.0",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/vitest/node_modules/why-is-node-running": {
-			"version": "2.3.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"siginfo": "^2.0.0",
-				"stackback": "0.0.2"
-			},
-			"bin": {
-				"why-is-node-running": "cli.js"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/w3c-xmlserializer": {
@@ -12561,6 +12556,23 @@
 			},
 			"engines": {
 				"node": ">=20"
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/xml-name-validator": {
@@ -12640,14 +12652,6 @@
 			"version": "10.6.0",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/yargs/node_modules/escalade": {
-			"version": "3.2.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
 		},
 		"node_modules/yargs/node_modules/get-caller-file": {
 			"version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"@tanstack/react-virtual": "^3.14.7",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
+		"cn": "^0.2.6",
 		"country-flag-icons": "^1.6.20",
 		"d3": "^7.9.0",
 		"html-to-image": "^1.11.13",
@@ -44,10 +45,9 @@
 		"radix-ui": "^1.4.3",
 		"react": "^19.2.5",
 		"react-dom": "^19.2.5",
-		"shadcn": "^4.13.0",
+		"shadcn": "^4.21.0",
 		"tailwind-merge": "^3.6.0",
 		"tailwindcss": "^4.3.0",
-		"topojson-client": "^3.1.0",
 		"tw-animate-css": "^1.4.0"
 	},
 	"devDependencies": {
@@ -66,7 +66,7 @@
 		"@types/react-dom": "^19.2.3",
 		"@types/topojson-client": "^3.1.5",
 		"@vitejs/plugin-react": "^6.0.1",
-		"@vitest/coverage-v8": "^4.1.8",
+		"@vitest/coverage-v8": "^4.1.11",
 		"eslint": "^10.2.1",
 		"eslint-plugin-react-hooks": "^7.1.1",
 		"eslint-plugin-react-refresh": "^0.5.2",
@@ -80,7 +80,6 @@
 		"typescript": "~6.0.2",
 		"typescript-eslint": "^8.58.2",
 		"vite": "^8.0.10",
-		"vitest": "^4.1.8",
-		"zod": "^4.3.6"
+		"vitest": "^4.1.11"
 	}
 }

--- a/src/shared/components/ui/button.tsx
+++ b/src/shared/components/ui/button.tsx
@@ -1,17 +1,16 @@
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "cn";
 import { Slot } from "radix-ui";
 
-import { cn } from "@/shared/lib/utils";
-
 const buttonVariants = cva(
-	"group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-xs/relaxed font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+	"group/button inline-flex shrink-0 items-center justify-center rounded-2xl border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 	{
 		variants: {
 			variant: {
 				default: "bg-primary text-primary-foreground hover:bg-primary/80",
 				outline:
-					"border-border hover:bg-input/50 hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:bg-input/30",
+					"border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:bg-transparent dark:hover:bg-input/30",
 				secondary:
 					"bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
 				ghost:
@@ -22,14 +21,14 @@ const buttonVariants = cva(
 			},
 			size: {
 				"default":
-					"h-7 gap-1 px-2 text-xs/relaxed has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
-				"xs": "h-5 gap-1 rounded-sm px-2 text-[0.625rem] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-2.5",
-				"sm": "h-6 gap-1 px-2 text-xs/relaxed has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-				"lg": "h-8 gap-1 px-2.5 text-xs/relaxed has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 [&_svg:not([class*='size-'])]:size-4",
-				"icon": "size-7 [&_svg:not([class*='size-'])]:size-3.5",
-				"icon-xs": "size-5 rounded-sm [&_svg:not([class*='size-'])]:size-2.5",
-				"icon-sm": "size-6 [&_svg:not([class*='size-'])]:size-3",
-				"icon-lg": "size-8 [&_svg:not([class*='size-'])]:size-4"
+					"h-8 gap-1.5 px-3 has-data-[icon=inline-end]:pr-2.5 has-data-[icon=inline-start]:pl-2.5",
+				"xs": "h-6 gap-1 px-2.5 text-xs has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2 [&_svg:not([class*='size-'])]:size-3",
+				"sm": "h-7 gap-1 px-3 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+				"lg": "h-9 gap-1.5 px-4 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
+				"icon": "size-8",
+				"icon-xs": "size-6 [&_svg:not([class*='size-'])]:size-3",
+				"icon-sm": "size-7",
+				"icon-lg": "size-9"
 			}
 		},
 		defaultVariants: {

--- a/src/shared/lib/utils.ts
+++ b/src/shared/lib/utils.ts
@@ -1,6 +1,1 @@
-import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
-
-export function cn(...inputs: ClassValue[]) {
-	return twMerge(clsx(inputs));
-}
+export { cn } from "cn";


### PR DESCRIPTION
- [x] Reinitialized `shadcn` configuration to use Vite and Base UI primitives (`components.json`, `index.css`, and basic UI utilities).
- [x] Removed unused dependencies: `zod`, `octokit`, and `topojson-client`.
- [x] Updated `vitest` and `@vitest/coverage-v8` to version `4.1.11` to resolve security vulnerabilities reported by `npm audit`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated button styling with revised corner rounding, typography, focus states, spacing, sizing, and icon dimensions.
  - Refined outline button backgrounds for improved visual consistency.
  - Updated the interface icon set, which may change the appearance of existing icons.
- **Refactor**
  - Standardized class-name handling across shared interface components without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->